### PR TITLE
ci: add SonarCloud analysis with code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -25,14 +27,50 @@ jobs:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Install SonarScanner
+        if: env.SONAR_TOKEN != ''
+        run: dotnet tool install --global dotnet-sonarscanner
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
       - name: Restore
         run: dotnet restore
+
+      - name: SonarCloud Begin
+        if: env.SONAR_TOKEN != ''
+        run: |
+          dotnet sonarscanner begin \
+            /k:"jfmeyers_jfm-roslyn-navigator" \
+            /o:"jfmeyers" \
+            /d:sonar.host.url="https://sonarcloud.io" \
+            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" \
+            /d:sonar.coverage.exclusions="**/Tests/**,**/Program.cs" \
+            /d:sonar.qualitygate.wait=true
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Build
         run: dotnet build --no-restore -c Release
 
       - name: Test
-        run: dotnet test --no-build -c Release --logger "trx;LogFileName=results.trx"
+        run: |
+          dotnet test --no-build -c Release \
+            --logger "trx;LogFileName=results.trx" \
+            --collect:"XPlat Code Coverage" \
+            --settings tests/coverlet.runsettings
+
+      - name: SonarCloud End
+        if: env.SONAR_TOKEN != ''
+        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Pack
         run: dotnet pack --no-build -c Release -o ./nupkgs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             /k:"jfmeyers_jfm-roslyn-navigator" \
             /o:"jfmeyers" \
             /d:sonar.host.url="https://sonarcloud.io" \
-            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+            /d:sonar.token="$SONAR_TOKEN" \
             /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" \
             /d:sonar.coverage.exclusions="**/Tests/**,**/Program.cs" \
             /d:sonar.qualitygate.wait=true
@@ -68,7 +68,7 @@ jobs:
 
       - name: SonarCloud End
         if: env.SONAR_TOKEN != ''
-        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+        run: dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,5 +16,6 @@
     <PackageVersion Include="xunit.v3" Version="3.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Instead of reading entire `.cs` files (500-2000+ tokens each), Claude Code queri
 
 ## Installation
 
+[![NuGet](https://img.shields.io/nuget/v/JFM.RoslynNavigator)](https://www.nuget.org/packages/JFM.RoslynNavigator/)
+
 ```bash
 dotnet tool install --global JFM.RoslynNavigator
 ```
@@ -153,6 +155,10 @@ Key design decisions:
 ## Acknowledgments
 
 Inspired by [CWM.RoslynNavigator](https://github.com/codewithmukesh/dotnet-claude-kit/tree/main/mcp/CWM.RoslynNavigator) by Mukesh Murugan (MIT License). Adapted with additional detectors, auto-discovery, and global tool distribution.
+
+## Documentation
+
+Full documentation is available in the [docs/](docs/README.md) directory.
 
 ## License
 

--- a/tests/JFM.RoslynNavigator.Tests/JFM.RoslynNavigator.Tests.csproj
+++ b/tests/JFM.RoslynNavigator.Tests/JFM.RoslynNavigator.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/coverlet.runsettings
+++ b/tests/coverlet.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>opencover</Format>
+          <Include>[JFM.RoslynNavigator]*</Include>
+          <Exclude>[*.Tests]*</Exclude>
+          <ExcludeByAttribute>
+            Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute
+          </ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary

- Add SonarCloud integration to CI pipeline with coverlet.collector 8.0.0 for OpenCover coverage reports
- Enable Quality Gate check that blocks CI on failure
- Add NuGet badge and documentation link to README

## Test plan

- [x] Verify CI workflow runs SonarCloud analysis on this PR
- [x] Confirm coverage report appears in SonarCloud dashboard
- [x] Verify Quality Gate status is reported on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)