### PR TITLE
fix: address final SonarCloud code smells

### DIFF
--- a/src/JFM.RoslynNavigator/Tools/DetectAntiPatternsTool.cs
+++ b/src/JFM.RoslynNavigator/Tools/DetectAntiPatternsTool.cs
@@ -45,20 +45,32 @@ public static class DetectAntiPatternsTool
             var compilation = await workspace.GetCompilationAsync(project, ct);
             if (compilation is null) continue;
 
-            foreach (var tree in compilation.SyntaxTrees)
-            {
-                ct.ThrowIfCancellationRequested();
-                if (violations.Count >= maxResults) break;
-
-                if (!MatchesFileFilter(tree, file)) continue;
-
-                var model = compilation.GetSemanticModel(tree);
-                AnalyzeTree(model, tree, detectorList, severity, maxResults, violations, ct);
-            }
+            AnalyzeCompilation(compilation, file, detectorList, severity, maxResults, violations, ct);
         }
 
         var result = new AntiPatternsResult(violations, violations.Count);
         return JsonSerializer.Serialize(result);
+    }
+
+    private static void AnalyzeCompilation(
+        Compilation compilation,
+        string? file,
+        List<IAntiPatternDetector> detectors,
+        string severity,
+        int maxResults,
+        List<AntiPatternEntry> violations,
+        CancellationToken ct)
+    {
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (violations.Count >= maxResults) break;
+
+            if (!MatchesFileFilter(tree, file)) continue;
+
+            var model = compilation.GetSemanticModel(tree);
+            AnalyzeTree(model, tree, detectors, severity, maxResults, violations, ct);
+        }
     }
 
     private static bool MatchesFileFilter(SyntaxTree tree, string? file)

--- a/src/JFM.RoslynNavigator/Tools/ValidateGranitConventionsTool.cs
+++ b/src/JFM.RoslynNavigator/Tools/ValidateGranitConventionsTool.cs
@@ -71,7 +71,7 @@ public static class ValidateGranitConventionsTool
                 continue;
             }
 
-            await AnalyzeCompilationAsync(compilation, project, file, checkCategory, violations, ct);
+            await AnalyzeCompilationAsync(compilation, file, checkCategory, violations, ct);
         }
 
         var byCategory = violations
@@ -84,7 +84,6 @@ public static class ValidateGranitConventionsTool
 
     private static async Task AnalyzeCompilationAsync(
         Compilation compilation,
-        Project project,
         string? file,
         string checkCategory,
         List<ConventionViolation> violations,
@@ -212,20 +211,18 @@ public static class ValidateGranitConventionsTool
                 continue;
             }
 
-            foreach (var prefix in genericPrefixes)
+            var matchedPrefix = genericPrefixes.FirstOrDefault(p => name == p + "Request" || name == p + "Response");
+            if (matchedPrefix is not null)
             {
-                if (name == prefix + "Request" || name == prefix + "Response")
-                {
-                    var line = typeDecl.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-                    yield return new ConventionViolation(
-                        CategoryNaming,
-                        "GR-ENDPOINT-PREFIX",
-                        "Warning",
-                        $"Endpoint DTO '{name}' uses a generic name — OpenAPI flattens namespaces causing schema conflicts",
-                        filePath,
-                        line,
-                        $"Prefix with module context (e.g. 'Workflow{name}' instead of '{name}')");
-                }
+                var line = typeDecl.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                yield return new ConventionViolation(
+                    CategoryNaming,
+                    "GR-ENDPOINT-PREFIX",
+                    "Warning",
+                    $"Endpoint DTO '{name}' uses a generic name — OpenAPI flattens namespaces causing schema conflicts",
+                    filePath,
+                    line,
+                    $"Prefix with module context (e.g. 'Workflow{name}' instead of '{name}')");
             }
         }
     }


### PR DESCRIPTION
## Summary

- Remove unused `project` parameter from `AnalyzeCompilationAsync` in ValidateGranitConventionsTool
- Extract `AnalyzeCompilation` method to reduce `DetectAntiPatternsTool.ExecuteAsync` complexity (17→<15)
- Replace `foreach`+`if` with LINQ `FirstOrDefault` in `CheckEndpointPrefixConventions`

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 41/41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)