### PR TITLE
test: improve coverage to pass 80% Quality Gate

### DIFF
--- a/tests/JFM.RoslynNavigator.Tests/Analyzers/HardcodedSecretDetectorTests.cs
+++ b/tests/JFM.RoslynNavigator.Tests/Analyzers/HardcodedSecretDetectorTests.cs
@@ -124,4 +124,93 @@ public class HardcodedSecretDetectorTests
         var violations = _detector.Detect(tree, null, TestContext.Current.CancellationToken).ToList();
         violations.ShouldBeEmpty();
     }
+
+    [Fact]
+    public void Ignores_Non_String_Literal_In_Object_Initializer()
+    {
+        const string source = """
+            public class Settings
+            {
+                public int Token { get; set; }
+            }
+            public class Config
+            {
+                public void Setup()
+                {
+                    var s = new Settings { Token = 42 };
+                }
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var violations = _detector.Detect(tree, null, TestContext.Current.CancellationToken).ToList();
+        violations.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Ignores_Non_Sensitive_Name_In_Object_Initializer()
+    {
+        const string source = """
+            public class Settings
+            {
+                public string Name { get; set; }
+            }
+            public class Config
+            {
+                public void Setup()
+                {
+                    var s = new Settings { Name = "hello" };
+                }
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var violations = _detector.Detect(tree, null, TestContext.Current.CancellationToken).ToList();
+        violations.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Ignores_Placeholder_In_Object_Initializer()
+    {
+        const string source = """
+            public class Settings
+            {
+                public string Password { get; set; }
+            }
+            public class Config
+            {
+                public void Setup()
+                {
+                    var s = new Settings { Password = "${ENV_PWD}" };
+                }
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var violations = _detector.Detect(tree, null, TestContext.Current.CancellationToken).ToList();
+        violations.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Detects_Secret_Via_MemberAccess_Assignment()
+    {
+        const string source = """
+            public class Config
+            {
+                public string Password { get; set; }
+            }
+            public class App
+            {
+                public void Run()
+                {
+                    var c = new Config();
+                    c.Password = "hardcoded123";
+                }
+            }
+            """;
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var violations = _detector.Detect(tree, null, TestContext.Current.CancellationToken).ToList();
+        violations.ShouldContain(v => v.Id == "GR-SECRET");
+    }
 }

--- a/tests/JFM.RoslynNavigator.Tests/SolutionDiscoveryTests.cs
+++ b/tests/JFM.RoslynNavigator.Tests/SolutionDiscoveryTests.cs
@@ -122,10 +122,22 @@ public class SolutionDiscoveryTests
     }
 
     [Fact]
-    public void FindSolutionPath_Returns_Null_Without_Args()
+    public void FindSolutionPath_Without_Explicit_Arg_Uses_Bfs()
     {
-        var result = SolutionDiscovery.FindSolutionPath([]);
-        // May return something if run from a dir with a .sln — just ensure no crash
-        _ = result;
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var cwd = Directory.GetCurrentDirectory();
+
+        try
+        {
+            Directory.SetCurrentDirectory(tempDir);
+            var result = SolutionDiscovery.FindSolutionPath([]);
+            result.ShouldBeNull();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(cwd);
+            Directory.Delete(tempDir, true);
+        }
     }
 }

--- a/tests/JFM.RoslynNavigator.Tests/SolutionDiscoveryTests.cs
+++ b/tests/JFM.RoslynNavigator.Tests/SolutionDiscoveryTests.cs
@@ -60,4 +60,72 @@ public class SolutionDiscoveryTests
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void BfsDiscovery_Finds_Sln_In_Subdirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        var subDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(subDir, "App.sln"), "");
+
+        try
+        {
+            var result = SolutionDiscovery.BfsDiscovery(tempDir);
+            result.ShouldNotBeNull();
+            result.ShouldEndWith("App.sln");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscovery_Prefers_Shallower_Depth()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        var subDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(tempDir, "Root.sln"), "");
+        File.WriteAllText(Path.Combine(subDir, "Nested.sln"), "");
+
+        try
+        {
+            var result = SolutionDiscovery.BfsDiscovery(tempDir);
+            result.ShouldNotBeNull();
+            result.ShouldEndWith("Root.sln");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscovery_Skips_Known_Directories()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        var binDir = Path.Combine(tempDir, "bin");
+        Directory.CreateDirectory(binDir);
+        File.WriteAllText(Path.Combine(binDir, "Hidden.sln"), "");
+
+        try
+        {
+            var result = SolutionDiscovery.BfsDiscovery(tempDir);
+            result.ShouldBeNull();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void FindSolutionPath_Returns_Null_Without_Args()
+    {
+        var result = SolutionDiscovery.FindSolutionPath([]);
+        // May return something if run from a dir with a .sln — just ensure no crash
+        _ = result;
+    }
 }


### PR DESCRIPTION
## Summary

- Add targeted tests for HardcodedSecretDetector (initializer edge cases, MemberAccess)
- Add targeted tests for SolutionDiscovery (subdirectory, depth preference, skip dirs)
- 49 tests total, all passing
- Coverage on modified analyzers now 90%+

## Test plan

- [x] `dotnet test` — 49/49 passed
- [x] Local coverage: HardcodedSecretDetector 92.8%, SolutionDiscovery 91.3%, MissingCancellationTokenDetector 90.9%

🤖 Generated with [Claude Code](https://claude.com/claude-code)