### PR TITLE
release: v1.1.0 — get_project_graph filtering

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,5 +1,9 @@
 {
   "MD013": {
     "tables": false
+  },
+  // Keep a Changelog uses repeated ### Added / ### Changed per version
+  "MD024": {
+    "siblings_only": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] - 2026-03-14
 
+Initial release as `JFM.RoslynNavigator`.
+
 ### Added
 
-- Initial release — Roslyn MCP server for Claude Code
+- 17 MCP navigation tools (find_symbol, find_references, find_callers,
+  find_implementations, find_overrides, find_dead_code, get_public_api,
+  get_symbol_detail, get_project_graph, get_dependency_graph,
+  get_module_depends_on, get_type_hierarchy, get_diagnostics,
+  get_test_coverage_map, detect_antipatterns, detect_circular_dependencies,
+  validate_granit_conventions)
+- 18 anti-pattern detectors
+- MSBuildWorkspace with LRU compilation cache
+- BFS solution auto-discovery (`.sln`/`.slnx`, max 3 levels)
+- Background async solution loading
+- GitHub Actions CI/CD (build + release + NuGet publish)
+- Global dotnet tool distribution (`dotnet tool install --global JFM.RoslynNavigator`)
 
 [1.0.0]: https://github.com/jfmeyers/roslyn-lens/compare/v0.1.1...v1.0.0
 [0.1.1]: https://github.com/jfmeyers/roslyn-lens/releases/tag/v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-20
+
+### Changed
+
+- `get_project_graph` now supports filtering by project name (`projectFilter`),
+  transitive dependency expansion (`includeTransitive`), and result limiting
+  (`maxResults`, default 50) to prevent output overflow on large solutions
+
 ## [1.0.0] - 2026-03-19
 
 ### Added
@@ -59,5 +67,6 @@ Initial release as `JFM.RoslynNavigator`.
 - GitHub Actions CI/CD (build + release + NuGet publish)
 - Global dotnet tool distribution (`dotnet tool install --global JFM.RoslynNavigator`)
 
+[1.1.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/jfmeyers/roslyn-lens/compare/v0.1.1...v1.0.0
 [0.1.1]: https://github.com/jfmeyers/roslyn-lens/releases/tag/v0.1.1

--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jfmeyers_roslyn-lens&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jfmeyers_roslyn-lens)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-A token-efficient MCP (Model Context Protocol) server for .NET codebase navigation, powered by Roslyn semantic analysis. Designed for use with [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
+A token-efficient MCP (Model Context Protocol) server for .NET codebase
+navigation, powered by Roslyn semantic analysis. Designed for use with
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
-Instead of reading entire `.cs` files (500-2000+ tokens each), Claude Code queries this MCP server and receives focused, semantic results (30-150 tokens). This dramatically reduces token consumption when working with large .NET solutions.
+Instead of reading entire `.cs` files (500-2000+ tokens each), Claude Code
+queries this MCP server and receives focused, semantic results (30-150
+tokens). This dramatically reduces token consumption when working with
+large .NET solutions.
 
 ## Features
 
@@ -24,7 +29,7 @@ Instead of reading entire `.cs` files (500-2000+ tokens each), Claude Code queri
 | `get_type_hierarchy` | Show inheritance chain, interfaces, and derived types |
 | `get_public_api` | Get public surface without reading the full file |
 | `get_symbol_detail` | Full signature, parameters, return type, and XML docs |
-| `get_project_graph` | Solution dependency tree |
+| `get_project_graph` | Solution dependency tree (with filtering for large solutions) |
 | `get_dependency_graph` | Method call chain visualization |
 | `get_diagnostics` | Compiler warnings and errors |
 | `get_test_coverage_map` | Heuristic test coverage mapping |
@@ -115,7 +120,9 @@ Or via `.mcp.json` in your project root:
 
 ### Solution Discovery
 
-The server automatically finds the nearest `.sln` or `.slnx` file using BFS from the current directory (max 3 levels up). You can also specify a solution explicitly:
+The server automatically finds the nearest `.sln` or `.slnx` file using
+BFS from the current directory (max 3 levels up). You can also specify a
+solution explicitly:
 
 ```bash
 roslyn-lens --solution /path/to/MySolution.slnx
@@ -158,7 +165,7 @@ Environment variables for runtime tuning:
 
 ## Architecture
 
-```
+```text
 src/RoslynLens/
 ├── Program.cs                  # Host + MCP stdio transport
 ├── SolutionDiscovery.cs        # BFS .sln/.slnx auto-discovery
@@ -177,14 +184,21 @@ src/RoslynLens/
 
 Key design decisions:
 
-- **Lazy compilation**: Solutions with 50+ projects only compile on-demand (LRU cache of 50 compilations)
-- **File watcher**: `.cs` changes trigger incremental text updates; `.csproj` changes trigger full reload
-- **Background loading**: Solution loads asynchronously; tools return "loading" status until ready
-- **Logs to stderr**: All logging goes to stderr to keep stdout clean for JSON-RPC
+- **Lazy compilation**: Solutions with 50+ projects only compile
+  on-demand (LRU cache of 50 compilations)
+- **File watcher**: `.cs` changes trigger incremental text updates;
+  `.csproj` changes trigger full reload
+- **Background loading**: Solution loads asynchronously; tools return
+  "loading" status until ready
+- **Logs to stderr**: All logging goes to stderr to keep stdout clean
+  for JSON-RPC
 
 ## Acknowledgments
 
-Inspired by [CWM.RoslynNavigator](https://github.com/codewithmukesh/dotnet-claude-kit/tree/main/mcp/CWM.RoslynNavigator) by Mukesh Murugan (MIT License). Adapted with additional detectors, auto-discovery, and global tool distribution.
+Inspired by
+[CWM.RoslynNavigator](https://github.com/codewithmukesh/dotnet-claude-kit/tree/main/mcp/CWM.RoslynNavigator)
+by Mukesh Murugan (MIT License). Adapted with additional detectors,
+auto-discovery, and global tool distribution.
 
 ## Documentation
 

--- a/docs/tools/project.md
+++ b/docs/tools/project.md
@@ -2,15 +2,25 @@
 
 ## get_project_graph
 
-Show the solution's project dependency tree.
+Show the solution's project dependency tree. Supports filtering for large
+solutions (100+ projects) to avoid output overflow.
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
-| (none) | | | |
+| `projectFilter` | string | no | Comma-separated project name filter (substring match, e.g. `Granit.AI,Granit.Core`) |
+| `includeTransitive` | bool | no | Include transitive dependencies of filtered projects (default: `false`) |
+| `maxResults` | int | no | Maximum projects to return (default: `50`) |
 
-**Example prompt:** "Show the project dependency graph"
+**Example prompts:**
 
-**Returns:** Each project with its direct project references.
+- "Show the project dependency graph" (returns first 50 projects)
+- "Show project graph for Granit.AI modules" → `projectFilter: "Granit.AI"`
+- "Show Granit.Security and all its dependencies" →
+  `projectFilter: "Granit.Security", includeTransitive: true`
+
+**Returns:** Each project with its name, target framework, and direct project
+references. `Total` reflects the full count of matching projects (even if
+truncated by `maxResults`).
 
 ---
 

--- a/src/RoslynLens/RoslynLens.csproj
+++ b/src/RoslynLens/RoslynLens.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>roslyn-lens</ToolCommandName>
     <PackageId>RoslynLens</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Description>Token-efficient .NET codebase navigation via Roslyn semantic analysis for Claude Code MCP</Description>
     <Authors>Jean-François Meyers</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/RoslynLens/Tools/GetProjectGraphTool.cs
+++ b/src/RoslynLens/Tools/GetProjectGraphTool.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Text.Json;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
 using RoslynLens.Responses;
 using ModelContextProtocol.Server;
 
@@ -10,9 +11,12 @@ namespace RoslynLens;
 public static class GetProjectGraphTool
 {
     [McpServerTool(Name = "get_project_graph")]
-    [Description("Returns the project dependency graph for the loaded solution, including target frameworks.")]
+    [Description("Returns the project dependency graph for the loaded solution, including target frameworks. Use projectFilter for large solutions.")]
     public static Task<string> ExecuteAsync(
         WorkspaceManager workspace,
+        [Description("Optional project name filter (comma-separated, supports substring match e.g. 'Granit.AI,Granit.Core')")] string? projectFilter = null,
+        [Description("Include transitive dependencies of filtered projects (default false)")] bool includeTransitive = false,
+        [Description("Maximum number of projects to return (default 50)")] int maxResults = 50,
         CancellationToken ct = default)
     {
         var status = workspace.EnsureReadyOrStatus(ct);
@@ -22,11 +26,31 @@ public static class GetProjectGraphTool
         if (solution is null)
             return Task.FromResult(JsonSerializer.Serialize(new { error = "No solution loaded" }));
 
+        var filters = projectFilter?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var allProjects = solution.Projects.ToList();
+        var matchingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (filters is not null)
+        {
+            foreach (var project in allProjects)
+            {
+                if (filters.Any(f => project.Name.Contains(f, StringComparison.OrdinalIgnoreCase)))
+                    matchingNames.Add(project.Name);
+            }
+
+            if (includeTransitive)
+                ExpandTransitiveDependencies(solution, allProjects, matchingNames);
+        }
+
         var nodes = new List<ProjectNode>();
 
-        foreach (var project in solution.Projects)
+        foreach (var project in allProjects)
         {
             ct.ThrowIfCancellationRequested();
+
+            if (filters is not null && !matchingNames.Contains(project.Name))
+                continue;
 
             var references = project.ProjectReferences
                 .Select(r => solution.GetProject(r.ProjectId)?.Name)
@@ -37,10 +61,37 @@ public static class GetProjectGraphTool
             var framework = ReadTargetFramework(project.FilePath);
 
             nodes.Add(new ProjectNode(project.Name, framework, references));
+
+            if (nodes.Count >= maxResults)
+                break;
         }
 
-        var result = new ProjectGraphResult(nodes, nodes.Count);
+        var totalMatching = filters is not null ? matchingNames.Count : allProjects.Count;
+        var result = new ProjectGraphResult(nodes, totalMatching);
         return Task.FromResult(JsonSerializer.Serialize(result));
+    }
+
+    private static void ExpandTransitiveDependencies(
+        Solution solution,
+        List<Project> allProjects,
+        HashSet<string> names)
+    {
+        var projectByName = allProjects.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<string>(names);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!projectByName.TryGetValue(current, out var project))
+                continue;
+
+            foreach (var refId in project.ProjectReferences)
+            {
+                var refProject = solution.GetProject(refId.ProjectId);
+                if (refProject is not null && names.Add(refProject.Name))
+                    queue.Enqueue(refProject.Name);
+            }
+        }
     }
 
     private static string? ReadTargetFramework(string? projectFilePath)


### PR DESCRIPTION
## Summary

- `get_project_graph` now supports `projectFilter` (comma-separated substring match),
  `includeTransitive` (BFS dependency expansion), and `maxResults` (default 50)
- Fixes output overflow on large solutions (granit-dotnet: 364 projects, 87K chars)
- Fixes pre-existing markdown lint errors in README.md and CHANGELOG.md

## Test plan

- [x] `dotnet build` passes
- [x] 144 existing tests pass
- [x] `markdownlint-cli2` passes on all changed files
- [ ] Manual test with granit-dotnet: `get_project_graph(projectFilter: "Granit.AI")`
- [ ] Manual test: `get_project_graph()` returns first 50 projects (no overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)