### PR TITLE
Feature/multi solution handling

### DIFF
--- a/src/RoslynLens/Program.cs
+++ b/src/RoslynLens/Program.cs
@@ -10,6 +10,7 @@ MSBuildLocator.RegisterDefaults();
 
 var solutionPath = SolutionDiscovery.FindSolutionPath(args);
 WorkspaceInitializer.SolutionPath = solutionPath;
+WorkspaceInitializer.DiscoveredSolutions = SolutionDiscovery.BfsDiscoverAll(Directory.GetCurrentDirectory());
 
 var config = RoslynLensConfig.FromEnvironment();
 

--- a/src/RoslynLens/Responses/ToolResponses.cs
+++ b/src/RoslynLens/Responses/ToolResponses.cs
@@ -151,3 +151,7 @@ public record DetailBatchResult(List<DetailBatchItem> Items, int Total, int Succ
 // validate_granit_conventions (Granit-specific)
 public record ConventionViolation(string Category, string Id, string Severity, string Message, string? File, int? Line, string? Suggestion);
 public record GranitConventionsResult(List<ConventionViolation> Violations, int Total, Dictionary<string, int> ByCategory);
+
+// list_solutions
+public record SolutionEntry(string Path, string Name, bool IsActive);
+public record ListSolutionsResult(List<SolutionEntry> Solutions, string? Hint);

--- a/src/RoslynLens/SolutionDiscovery.cs
+++ b/src/RoslynLens/SolutionDiscovery.cs
@@ -6,13 +6,13 @@ namespace RoslynLens;
 /// </summary>
 public static class SolutionDiscovery
 {
-    private static readonly HashSet<string> SkipDirectories = new(StringComparer.OrdinalIgnoreCase)
+    internal static readonly HashSet<string> SkipDirectories = new(StringComparer.OrdinalIgnoreCase)
     {
         ".git", ".vs", ".idea", "node_modules", "bin", "obj",
         "packages", "artifacts", "TestResults", ".claude", "nupkgs"
     };
 
-    private const int MaxBfsDepth = 3;
+    public const int MaxBfsDepth = 3;
 
     public static string? FindSolutionPath(string[] args)
     {

--- a/src/RoslynLens/SolutionDiscovery.cs
+++ b/src/RoslynLens/SolutionDiscovery.cs
@@ -75,6 +75,42 @@ public static class SolutionDiscovery
         return bestMatch;
     }
 
+    public static IReadOnlyList<string> BfsDiscoverAll(string startDirectory)
+    {
+        var queue = new Queue<(string Path, int Depth)>();
+        queue.Enqueue((startDirectory, 0));
+
+        var results = new List<(string FullPath, int Depth)>();
+
+        while (queue.Count > 0)
+        {
+            var (dirPath, depth) = queue.Dequeue();
+
+            if (depth > MaxBfsDepth)
+                continue;
+
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(dirPath).Where(IsSolutionFile))
+                {
+                    results.Add((Path.GetFullPath(file), depth));
+                }
+
+                EnqueueSubDirectories(queue, dirPath, depth);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Skip directories we can't access
+            }
+        }
+
+        return results
+            .OrderBy(r => r.Depth)
+            .ThenBy(r => r.FullPath, StringComparer.OrdinalIgnoreCase)
+            .Select(r => r.FullPath)
+            .ToList();
+    }
+
     private static string? ScanDirectoryForSolution(string dirPath, int depth, string? currentBest, ref int bestDepth)
     {
         foreach (var file in Directory.EnumerateFiles(dirPath).Where(IsSolutionFile))

--- a/src/RoslynLens/Tools/ListSolutionsTool.cs
+++ b/src/RoslynLens/Tools/ListSolutionsTool.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynLens.Responses;
+
+namespace RoslynLens;
+
+[McpServerToolType]
+public static class ListSolutionsTool
+{
+    [McpServerTool(Name = "list_solutions")]
+    [Description("Lists all discovered solution files with their paths and which one is currently active.")]
+    public static Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        CancellationToken ct = default)
+    {
+        var discovered = WorkspaceInitializer.DiscoveredSolutions;
+        var activePath = WorkspaceInitializer.SolutionPath;
+
+        var entries = discovered.Select(path => new SolutionEntry(
+            path,
+            Path.GetFileName(path),
+            string.Equals(path, activePath, StringComparison.OrdinalIgnoreCase)
+        )).ToList();
+
+        var hint = workspace.GetMultiSolutionHint();
+        var result = new ListSolutionsResult(entries, hint);
+
+        return Task.FromResult(Json.Serialize(result));
+    }
+}

--- a/src/RoslynLens/Tools/SwitchSolutionTool.cs
+++ b/src/RoslynLens/Tools/SwitchSolutionTool.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace RoslynLens;
+
+[McpServerToolType]
+public static class SwitchSolutionTool
+{
+    [McpServerTool(Name = "switch_solution")]
+    [Description("Switch to a different solution from the discovered list. Use list_solutions to see available options.")]
+    public static async Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        [Description("Full path to the solution file (must be one of the discovered solutions)")] string solutionPath,
+        CancellationToken ct = default)
+    {
+        var discovered = WorkspaceInitializer.DiscoveredSolutions;
+
+        if (!discovered.Any(p => string.Equals(p, solutionPath, StringComparison.OrdinalIgnoreCase)))
+        {
+            return Json.Serialize(new
+            {
+                Error = $"Path not in discovered solutions list. Use list_solutions to see available options.",
+                Discovered = discovered
+            });
+        }
+
+        try
+        {
+            await workspace.ReloadSolutionAsync(solutionPath, ct);
+            WorkspaceInitializer.SolutionPath = solutionPath;
+
+            return Json.Serialize(new
+            {
+                Status = "switched",
+                Solution = Path.GetFileName(solutionPath),
+                ProjectCount = workspace.ProjectCount
+            });
+        }
+        catch (Exception ex)
+        {
+            return Json.Serialize(new
+            {
+                Error = $"Failed to switch solution: {ex.Message}",
+                State = workspace.State.ToString()
+            });
+        }
+    }
+}

--- a/src/RoslynLens/WorkspaceInitializer.cs
+++ b/src/RoslynLens/WorkspaceInitializer.cs
@@ -16,12 +16,26 @@ public sealed class WorkspaceInitializer(
     /// </summary>
     public static string? SolutionPath { get; set; }
 
+    /// <summary>
+    /// All solution files discovered via BFS. Set by Program.cs before host starts.
+    /// </summary>
+    public static IReadOnlyList<string> DiscoveredSolutions { get; set; } = [];
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (SolutionPath is null)
         {
             logger.LogWarning("No solution file found. Use --solution <path> or run from a directory containing a .sln/.slnx file.");
             return;
+        }
+
+        if (DiscoveredSolutions.Count > 1)
+        {
+            logger.LogWarning(
+                "Multiple solutions discovered ({Count}). Auto-selected: {Selected}. Use list_solutions and switch_solution tools to change. Solutions: {Solutions}",
+                DiscoveredSolutions.Count,
+                SolutionPath,
+                string.Join(", ", DiscoveredSolutions));
         }
 
         if (logger.IsEnabled(LogLevel.Information))

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -65,6 +65,26 @@ public sealed class WorkspaceManager : IDisposable
         }
     }
 
+    public async Task ReloadSolutionAsync(string solutionPath, CancellationToken ct)
+    {
+        DisposeCurrentWorkspace();
+        await LoadSolutionAsync(solutionPath, ct);
+    }
+
+    private void DisposeCurrentWorkspace()
+    {
+        _sourceWatcher?.Dispose();
+        _sourceWatcher = null;
+        _projectWatcher?.Dispose();
+        _projectWatcher = null;
+        _workspace?.Dispose();
+        _workspace = null;
+        _solution = null;
+        _solutionDirectory = null;
+        _compilationCache.Clear();
+        ErrorMessage = null;
+    }
+
     public string? EnsureReadyOrStatus(CancellationToken ct)
     {
         if (State == WorkspaceState.Ready)
@@ -196,9 +216,7 @@ public sealed class WorkspaceManager : IDisposable
 
     public void Dispose()
     {
-        _sourceWatcher?.Dispose();
-        _projectWatcher?.Dispose();
-        _workspace?.Dispose();
+        DisposeCurrentWorkspace();
         _writeLock.Dispose();
     }
 }

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -94,6 +94,15 @@ public sealed class WorkspaceManager : IDisposable
         return Json.Serialize(status);
     }
 
+    public string? GetMultiSolutionHint()
+    {
+        var discovered = WorkspaceInitializer.DiscoveredSolutions;
+        if (discovered.Count <= 1)
+            return null;
+
+        return $"hint: {discovered.Count} solutions discovered. Use list_solutions to see options and switch_solution to change.";
+    }
+
     public Solution? GetSolution() => _solution;
 
     public async Task<Compilation?> GetCompilationAsync(Project project, CancellationToken ct)

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -2,228 +2,211 @@ using Shouldly;
 
 namespace RoslynLens.Tests;
 
-public class SolutionDiscoveryTests
+public class SolutionDiscoveryTests : IDisposable
 {
+    private readonly string _tempDir;
+
+    #region Test plumbing
+
+    /// <summary>
+    /// Initializes a new instance of the SolutionDiscoveryTests class and prepares the test environment.
+    /// </summary>
+    /// <remarks>Creates the temporary directory required for test execution. This constructor is intended for
+    /// use in test setup scenarios.</remarks>
+    public SolutionDiscoveryTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        Console.WriteLine("[SolutionDiscoveryTests] Created temp directory: {0}", _tempDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDir, true);
+            Console.WriteLine("[SolutionDiscoveryTests] Deleted temp directory: {0}", _tempDir);
+        }
+        catch 
+        { 
+        }
+    }
+
+    #endregion
+
+    private string CreateSubDir(string name)
+    {
+        var path = Path.Combine(_tempDir, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private string CreateSolutionFile(string relativePath, string? content = null)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath);
+        var dir = Path.GetDirectoryName(fullPath)!;
+        
+        Directory.CreateDirectory(dir);
+
+        if (string.IsNullOrEmpty(content))
+        {
+            content = Path.GetExtension(fullPath) switch {
+                ".slnx" => "<Solution />",
+                ".sln" => """
+                       
+                       Microsoft Visual Studio Solution File, Format Version 12.00
+                       # Visual Studio Version 17
+                       """,
+                _ => ""
+            };
+        }
+
+        File.WriteAllText(fullPath, content);
+        return fullPath;
+    }
+
     [Fact]
     public void FindSolutionPath_With_Explicit_Arg_Returns_Path()
     {
-        // Create a temp directory with a solution file
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        var slnPath = Path.Combine(tempDir, "Test.slnx");
-        File.WriteAllText(slnPath, "<Solution />");
+        var slnPath = CreateSolutionFile("Test.slnx");
 
-        try
-        {
-            var result = SolutionDiscovery.FindSolutionPath(["--solution", slnPath]);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("Test.slnx");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.FindSolutionPath(["--solution", slnPath]);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("Test.slnx");
     }
 
     [Fact]
     public void BfsDiscovery_Finds_Slnx_In_Current_Dir()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        File.WriteAllText(Path.Combine(tempDir, "MyApp.slnx"), "<Solution />");
+        CreateSolutionFile("MyApp.slnx");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("MyApp.slnx");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("MyApp.slnx");
     }
 
     [Fact]
     public void BfsDiscovery_Returns_Null_When_No_Solution()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldBeNull();
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldBeNull();
     }
 
     [Fact]
     public void BfsDiscovery_Finds_Sln_In_Subdirectory()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var subDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(subDir);
-        File.WriteAllText(Path.Combine(subDir, "App.sln"), "");
+        CreateSolutionFile(@"src\App.sln");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("App.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("App.sln");
     }
 
     [Fact]
     public void BfsDiscovery_Prefers_Shallower_Depth()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var subDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(subDir);
-        File.WriteAllText(Path.Combine(tempDir, "Root.sln"), "");
-        File.WriteAllText(Path.Combine(subDir, "Nested.sln"), "");
+        CreateSolutionFile("Root.sln");
+        CreateSolutionFile(@"src\Nested.sln");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("Root.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("Root.sln");
     }
 
     [Fact]
     public void BfsDiscovery_Skips_Known_Directories()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var binDir = Path.Combine(tempDir, "bin");
-        Directory.CreateDirectory(binDir);
-        File.WriteAllText(Path.Combine(binDir, "Hidden.sln"), "");
+        CreateSolutionFile(@"bin\Hidden.sln");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldBeNull();
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldBeNull();
     }
 
     [Fact]
-    public void BfsDiscoverAll_Returns_All_Solutions_In_Same_Directory()
+    public void BfsDiscovery_Returns_Null_Beyond_MaxBfsDepth()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        File.WriteAllText(Path.Combine(tempDir, "SolutionA.slnx"), "<Solution />");
-        File.WriteAllText(Path.Combine(tempDir, "A-Solution.slnx"), "<Solution />");
+        // MaxBfsDepth is 3, so depth 4 should be ignored
+        CreateSolutionFile(@"a\b\c\d\TooDeep.sln");
 
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.Count.ShouldBe(2);
-            results.ShouldContain(p => p.EndsWith("SolutionA.slnx"));
-            results.ShouldContain(p => p.EndsWith("A-Solution.slnx"));
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_ReturnsAllSolutions_InAllDirectories()
+    {
+        CreateSolutionFile("SolutionA.slnx");
+        CreateSolutionFile("A-Solution.slnx");
+        CreateSolutionFile(@"src\Nested.sln");
+
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(3);
+        results.ShouldContain(p => p.EndsWith("SolutionA.slnx"));
+        results.ShouldContain(p => p.EndsWith("A-Solution.slnx"));
+        results.ShouldContain(p => p.EndsWith("Nested.sln"));
     }
 
     [Fact]
     public void BfsDiscoverAll_Orders_By_Depth_Then_Alphabetically()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var subDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(subDir);
-        File.WriteAllText(Path.Combine(tempDir, "Root.sln"), "");
-        File.WriteAllText(Path.Combine(subDir, "Nested.sln"), "");
-        File.WriteAllText(Path.Combine(subDir, "Alpha.sln"), "");
+        CreateSolutionFile("Root.sln");
+        CreateSolutionFile(@"src\Nested.sln");
+        CreateSolutionFile(@"src\Alpha.sln");
 
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.Count.ShouldBe(3);
-            // Depth 0 first, then depth 1 alphabetically
-            results[0].ShouldEndWith("Root.sln");
-            results[1].ShouldEndWith("Alpha.sln");
-            results[2].ShouldEndWith("Nested.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(3);
+        // Depth 0 first, then depth 1 alphabetically
+        results[0].ShouldEndWith("Root.sln");
+        results[1].ShouldEndWith("Alpha.sln");
+        results[2].ShouldEndWith("Nested.sln");
     }
 
     [Fact]
     public void BfsDiscoverAll_Returns_Empty_When_No_Solutions()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.ShouldBeEmpty();
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.ShouldBeEmpty();
     }
 
     [Fact]
-    public void BfsDiscoverAll_Skips_Known_Directories()
+    public void BfsDiscoverAll_SkipsKnownDirectories()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var binDir = Path.Combine(tempDir, "bin");
-        var srcDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(binDir);
-        Directory.CreateDirectory(srcDir);
-        File.WriteAllText(Path.Combine(binDir, "Hidden.sln"), "");
-        File.WriteAllText(Path.Combine(srcDir, "Visible.sln"), "");
+        CreateSolutionFile(@"node_modules\skip_me.sln");
+        CreateSolutionFile(@"packages\Nupkg\whatever.slnx");
+        CreateSolutionFile(@"obj\skip_me_too.slnx");
+        CreateSolutionFile(@"src\Visible.sln");
 
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.Count.ShouldBe(1);
-            results[0].ShouldEndWith("Visible.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(1);
+        results[0].ShouldEndWith("Visible.sln");
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Ignores_Solutions_Beyond_MaxBfsDepth()
+    {
+        // MaxBfsDepth is 3, so depth 4 should be ignored
+        CreateSolutionFile("Root.sln");
+        CreateSolutionFile(@"a\b\c\d\TooDeep.slnx");
+
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(1);
+        results[0].ShouldEndWith("Root.sln");
     }
 
     [Fact]
     public void FindSolutionPath_Without_Explicit_Arg_Uses_Bfs()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
         var cwd = Directory.GetCurrentDirectory();
 
         try
         {
-            Directory.SetCurrentDirectory(tempDir);
+            Directory.SetCurrentDirectory(_tempDir);
             var result = SolutionDiscovery.FindSolutionPath([]);
             result.ShouldBeNull();
         }
         finally
         {
             Directory.SetCurrentDirectory(cwd);
-            Directory.Delete(tempDir, true);
         }
     }
 }

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -32,8 +32,6 @@ public class SolutionDiscoveryTests : IDisposable
         }
     }
 
-    #endregion
-
     private string CreateSubDir(string name)
     {
         var path = Path.Combine(_tempDir, name);
@@ -64,6 +62,8 @@ public class SolutionDiscoveryTests : IDisposable
         File.WriteAllText(fullPath, content);
         return fullPath;
     }
+
+    #endregion
 
     [Fact]
     public void FindSolutionPath_With_Explicit_Arg_Returns_Path()
@@ -171,6 +171,7 @@ public class SolutionDiscoveryTests : IDisposable
     [Fact]
     public void BfsDiscoverAll_SkipsKnownDirectories()
     {
+        // SolutionDiscovery has a list of ignored directories (e.g. node_modules, obj, bin, packages), so solutions in those should be skipped
         CreateSolutionFile(@"node_modules\skip_me.sln");
         CreateSolutionFile(@"packages\Nupkg\whatever.slnx");
         CreateSolutionFile(@"obj\skip_me_too.slnx");
@@ -184,6 +185,9 @@ public class SolutionDiscoveryTests : IDisposable
     [Fact]
     public void BfsDiscoverAll_Ignores_Solutions_Beyond_MaxBfsDepth()
     {
+        // Sanity check to ensure the constant is what we expect
+        SolutionDiscovery.MaxBfsDepth.ShouldBe(3);
+
         // MaxBfsDepth is 3, so depth 4 should be ignored
         CreateSolutionFile("Root.sln");
         CreateSolutionFile(@"a\b\c\d\TooDeep.slnx");

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -122,6 +122,92 @@ public class SolutionDiscoveryTests
     }
 
     [Fact]
+    public void BfsDiscoverAll_Returns_All_Solutions_In_Same_Directory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "SolutionA.slnx"), "<Solution />");
+        File.WriteAllText(Path.Combine(tempDir, "A-Solution.slnx"), "<Solution />");
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.Count.ShouldBe(2);
+            results.ShouldContain(p => p.EndsWith("SolutionA.slnx"));
+            results.ShouldContain(p => p.EndsWith("A-Solution.slnx"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Orders_By_Depth_Then_Alphabetically()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        var subDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(tempDir, "Root.sln"), "");
+        File.WriteAllText(Path.Combine(subDir, "Nested.sln"), "");
+        File.WriteAllText(Path.Combine(subDir, "Alpha.sln"), "");
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.Count.ShouldBe(3);
+            // Depth 0 first, then depth 1 alphabetically
+            results[0].ShouldEndWith("Root.sln");
+            results[1].ShouldEndWith("Alpha.sln");
+            results[2].ShouldEndWith("Nested.sln");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Returns_Empty_When_No_Solutions()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.ShouldBeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Skips_Known_Directories()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        var binDir = Path.Combine(tempDir, "bin");
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(binDir);
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(Path.Combine(binDir, "Hidden.sln"), "");
+        File.WriteAllText(Path.Combine(srcDir, "Visible.sln"), "");
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.Count.ShouldBe(1);
+            results[0].ShouldEndWith("Visible.sln");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void FindSolutionPath_Without_Explicit_Arg_Uses_Bfs()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");

--- a/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace RoslynLens.Tests.Tools;
+
+public class ListSolutionsToolTests : IDisposable
+{
+    private readonly WorkspaceManager _workspace;
+
+    public ListSolutionsToolTests()
+    {
+        var config = new RoslynLensConfig(30, 100, 50, LogLevel.Warning);
+        _workspace = new WorkspaceManager(config);
+    }
+
+    [Fact]
+    public async Task Returns_All_Discovered_Solutions_With_IsActive_Flag()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+        var originalPath = WorkspaceInitializer.SolutionPath;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions =
+            [
+                @"C:\repos\SolutionA.slnx",
+                @"C:\repos\SolutionB.slnx"
+            ];
+            WorkspaceInitializer.SolutionPath = @"C:\repos\SolutionA.slnx";
+
+            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            root.GetProperty("Solutions").GetArrayLength().ShouldBe(2);
+
+            var first = root.GetProperty("Solutions")[0];
+            first.GetProperty("Name").GetString().ShouldBe("SolutionA.slnx");
+            first.GetProperty("IsActive").GetBoolean().ShouldBeTrue();
+
+            var second = root.GetProperty("Solutions")[1];
+            second.GetProperty("Name").GetString().ShouldBe("SolutionB.slnx");
+            second.GetProperty("IsActive").GetBoolean().ShouldBeFalse();
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+            WorkspaceInitializer.SolutionPath = originalPath;
+        }
+    }
+
+    [Fact]
+    public async Task Returns_Empty_When_No_Solutions_Discovered()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = [];
+
+            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("Solutions").GetArrayLength().ShouldBe(0);
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    [Fact]
+    public async Task Includes_Multi_Solution_Hint_When_Multiple_Discovered()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+        var originalPath = WorkspaceInitializer.SolutionPath;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions =
+            [
+                @"C:\repos\A.slnx",
+                @"C:\repos\B.slnx",
+                @"C:\repos\C.slnx"
+            ];
+            WorkspaceInitializer.SolutionPath = @"C:\repos\A.slnx";
+
+            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var hint = doc.RootElement.GetProperty("Hint").GetString();
+            hint.ShouldNotBeNullOrEmpty();
+            hint.ShouldContain("3 solutions discovered");
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+            WorkspaceInitializer.SolutionPath = originalPath;
+        }
+    }
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+    }
+}

--- a/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace RoslynLens.Tests.Tools;
+
+public class SwitchSolutionToolTests : IDisposable
+{
+    private readonly WorkspaceManager _workspace;
+
+    public SwitchSolutionToolTests()
+    {
+        var config = new RoslynLensConfig(30, 100, 50, LogLevel.Warning);
+        _workspace = new WorkspaceManager(config);
+    }
+
+    [Fact]
+    public async Task Rejects_Path_Not_In_Discovered_List()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions =
+            [
+                @"C:\repos\SolutionA.slnx",
+                @"C:\repos\SolutionB.slnx"
+            ];
+
+            var result = await SwitchSolutionTool.ExecuteAsync(
+                _workspace,
+                @"C:\repos\Unknown.slnx",
+                TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var error = doc.RootElement.GetProperty("Error").GetString();
+            error.ShouldNotBeNullOrEmpty();
+            error.ShouldContain("not in discovered");
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    [Fact]
+    public async Task Rejects_When_No_Solutions_Discovered()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = [];
+
+            var result = await SwitchSolutionTool.ExecuteAsync(
+                _workspace,
+                @"C:\repos\Anything.slnx",
+                TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var error = doc.RootElement.GetProperty("Error").GetString();
+            error.ShouldNotBeNullOrEmpty();
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+    }
+}

--- a/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
+++ b/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace RoslynLens.Tests;
+
+public class WorkspaceManagerTests : IDisposable
+{
+    private readonly WorkspaceManager _manager;
+
+    public WorkspaceManagerTests()
+    {
+        var config = new RoslynLensConfig(30, 100, 50, LogLevel.Warning);
+        _manager = new WorkspaceManager(config);
+    }
+
+    [Fact]
+    public void Initial_State_Is_NotStarted()
+    {
+        _manager.State.ShouldBe(WorkspaceState.NotStarted);
+    }
+
+    [Fact]
+    public async Task ReloadSolutionAsync_Sets_State_To_Loading_Then_Error_For_Invalid_Path()
+    {
+        var ex = await Should.ThrowAsync<Exception>(
+            () => _manager.ReloadSolutionAsync("nonexistent.slnx", TestContext.Current.CancellationToken));
+
+        _manager.State.ShouldBe(WorkspaceState.Error);
+        _manager.ErrorMessage.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ReloadSolutionAsync_Resets_State_From_Ready()
+    {
+        // First load will fail — that's fine, we're testing state transitions
+        try
+        {
+            await _manager.LoadSolutionAsync("nonexistent.slnx", TestContext.Current.CancellationToken);
+        }
+        catch
+        {
+            // Expected
+        }
+
+        _manager.State.ShouldBe(WorkspaceState.Error);
+
+        // Reload should reset state and attempt fresh load
+        try
+        {
+            await _manager.ReloadSolutionAsync("also-nonexistent.slnx", TestContext.Current.CancellationToken);
+        }
+        catch
+        {
+            // Expected
+        }
+
+        // State should be Error (not stuck on old state)
+        _manager.State.ShouldBe(WorkspaceState.Error);
+    }
+
+    public void Dispose()
+    {
+        _manager.Dispose();
+    }
+}


### PR DESCRIPTION
# Summary

When a repository contains multiple .sln/.slnx files, RoslynLens previously auto-selected one arbitrarily and silently ignored the rest. 

This PR adds the ability to discover all solutions at startup and switch between them at runtime via two new MCP tools and basically enhances #40 

The key was adding hints that additional solutions had been found and reporting them to the underlying agent so that it could decide which solution file to use.  Basically (first still wins atm) but all options are presented to the agent for evaluation when there's multiple found.  Single solution still works as expected.

# What Changed

## New MCP Tools

 - list_solutions — Lists all discovered solution files with paths, names, and an IsActive flag indicating the currently loaded solution. 
Includes a hint when multiple solutions are available.
 - switch_solution — Switches the active workspace to a different discovered solution. Validates the path is in the discovered list and 
gracefully handles load failures.

## Core Changes

 - SolutionDiscovery.BfsDiscoverAll() — New BFS method that returns all solution files (ordered by depth, then alphabetically), rather than 
picking a single best match.
 - WorkspaceManager.ReloadSolutionAsync() — Cleanly disposes the current workspace (watchers, compilation cache, MSBuild workspace) and loads a 
new solution.
 - WorkspaceManager.GetMultiSolutionHint() — Returns a contextual hint string when multiple solutions are present, surfaced in tool responses.
 - WorkspaceInitializer.DiscoveredSolutions — Static property wired at startup to hold the full discovered list. Logs a warning when multiple 
solutions are found.
 - Dispose refactored — Extracted DisposeCurrentWorkspace() to share cleanup logic between Dispose() and ReloadSolutionAsync().

## New Response DTOs

 - SolutionEntry(Path, Name, IsActive)
 - ListSolutionsResult(Solutions, Hint)

## Tests Added (4 new test classes, 9 new tests)

 - SolutionDiscoveryTests — BFS discovery: multiple solutions, depth ordering, empty results, skipped directories
 - ListSolutionsToolTests — Active flag, empty list, multi-solution hint
 - SwitchSolutionToolTests — Rejects unknown paths, rejects when no solutions discovered
 - WorkspaceManagerTests — Initial state, reload error handling, reload + re-reload lifecycle

# Stats

11 files changed — 495 additions, 3 deletions
