### PR TITLE
feat: multi-solution handling (from #96 + review fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-04-14
+
+### Added
+
+- Multi-solution support: discover all `.sln`/`.slnx` files at
+  startup instead of silently picking one
+- `list_solutions` MCP tool — lists all discovered solutions with
+  path, name, and `IsActive` flag
+- `switch_solution` MCP tool — switch the active workspace to a
+  different discovered solution at runtime
+- `SolutionDiscovery.BfsDiscoverAll()` — returns all solutions
+  ordered by depth then alphabetically
+- `WorkspaceManager.ReloadSolutionAsync()` — full dispose + fresh
+  workspace reload with rollback on failure
+- `WorkspaceManager.GetMultiSolutionHint()` — contextual hint
+  when multiple solutions are present
+- Startup warning when multiple solutions are discovered
+
 ## [1.1.1] - 2026-03-26
 
 ### Fixed
@@ -80,6 +98,7 @@ Initial release as `JFM.RoslynNavigator`.
 - GitHub Actions CI/CD (build + release + NuGet publish)
 - Global dotnet tool distribution (`dotnet tool install --global JFM.RoslynNavigator`)
 
+[1.2.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/jfmeyers/roslyn-lens/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/jfmeyers/roslyn-lens/compare/v0.1.1...v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,11 +26,11 @@ dotnet tool install --global --add-source ./nupkgs RoslynLens
 | Path | Role |
 | ---- | ---- |
 | `Program.cs` | Host + MCP stdio transport (logs → stderr) |
-| `SolutionDiscovery.cs` | BFS `.sln`/`.slnx` auto-discovery (max 3 levels) |
-| `WorkspaceManager.cs` | MSBuildWorkspace, LRU cache (50), wait-for-ready |
-| `WorkspaceInitializer.cs` | BackgroundService for async solution loading |
+| `SolutionDiscovery.cs` | BFS `.sln`/`.slnx` auto-discovery, multi-solution |
+| `WorkspaceManager.cs` | MSBuildWorkspace, LRU cache (50), solution reload |
+| `WorkspaceInitializer.cs` | BackgroundService, discovered solutions registry |
 | `SymbolResolver.cs` | Cross-project symbol resolution with file/line disambiguation |
-| `Tools/` | 28 MCP tool implementations (one class per tool) |
+| `Tools/` | 30 MCP tool implementations (one class per tool) |
 | `Analyzers/` | 18 detectors + 2 base classes (`InvocationDetectorBase`, `ObjectCreationDetectorBase`) |
 | `Responses/` | Token-optimized DTOs (records) |
 
@@ -53,12 +53,24 @@ dotnet tool install --global --add-source ./nupkgs RoslynLens
 3. Use `CSharpSyntaxTree.ParseText(source)` in tests — no full compilation needed
 4. Use `TestContext.Current.CancellationToken` (not `CancellationToken.None`)
 
+## Multi-solution support
+
+When multiple `.sln`/`.slnx` files are discovered, RoslynLens logs
+a warning and auto-selects the shallowest/alphabetically first.
+Two MCP tools enable runtime switching:
+
+- `list_solutions` — all discovered solutions with `IsActive` flag
+- `switch_solution` — reload workspace with a different solution
+
+Discovery uses `BfsDiscoverAll()` rooted at the resolved
+solution's directory. Rollback restores previous solution on failure.
+
 ## Adding a new tool
 
 1. Create `src/.../Tools/MyTool.cs` with `[McpServerToolType]` attribute
 2. Tools are auto-discovered via `WithToolsFromAssembly()`
 3. Inject `WorkspaceManager` to access the solution/compilations
-4. Call `workspace.EnsureReadyOrStatus(ct)` — waits for ready (up to timeout), returns status JSON if not
+4. Call `workspace.EnsureReadyOrStatus(ct)` — returns status if not ready
 
 ## Release
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # RoslynLens Documentation
 
 A token-efficient MCP server for .NET codebase navigation via Roslyn.
-28 tools, 19 anti-pattern detectors, configurable and extensible.
+30 tools, 19 anti-pattern detectors, configurable and extensible.
 
 ## Getting Started
 
@@ -13,30 +13,36 @@ A token-efficient MCP server for .NET codebase navigation via Roslyn.
   environment variables, CLI args, tuning guide
 - [Troubleshooting](getting-started/troubleshooting.md) — common issues and fixes
 
-## Tools Reference (28 tools)
+## Tools Reference (30 tools)
 
 ### Core tools (17)
 
-- [Navigation Tools](tools/navigation.md) — find_symbol (with glob patterns),
-  find_references, find_implementations, find_callers, find_overrides
-- [Inspection Tools](tools/inspection.md) — get_public_api, get_symbol_detail,
-  get_type_hierarchy, get_dependency_graph
-- [Project Tools](tools/project.md) — get_project_graph, get_diagnostics,
-  get_test_coverage_map
+- [Navigation Tools](tools/navigation.md) — find_symbol (with glob
+  patterns), find_references, find_implementations, find_callers,
+  find_overrides
+- [Inspection Tools](tools/inspection.md) — get_public_api,
+  get_symbol_detail, get_type_hierarchy, get_dependency_graph
+- [Project Tools](tools/project.md) — get_project_graph,
+  get_diagnostics, get_test_coverage_map
 - [Analysis Tools](tools/analysis.md) — detect_antipatterns,
   detect_circular_dependencies, find_dead_code
-- [Modular Architecture Tools](tools/modular.md) — get_module_depends_on,
-  validate_conventions
+- [Modular Architecture Tools](tools/modular.md) —
+  get_module_depends_on, validate_conventions
 
 ### v1.1.0 tools (11)
 
-- [Advanced Analysis Tools](tools/advanced.md) — get_complexity_metrics,
-  analyze_data_flow, analyze_control_flow, detect_duplicates,
-  resolve_external_source
-- [Compound Tools](tools/compound.md) — analyze_method, get_type_overview,
-  get_file_overview
-- [Batch Tools](tools/batch.md) — find_symbols_batch, get_public_api_batch,
-  get_symbol_detail_batch
+- [Advanced Analysis Tools](tools/advanced.md) —
+  get_complexity_metrics, analyze_data_flow, analyze_control_flow,
+  detect_duplicates, resolve_external_source
+- [Compound Tools](tools/compound.md) — analyze_method,
+  get_type_overview, get_file_overview
+- [Batch Tools](tools/batch.md) — find_symbols_batch,
+  get_public_api_batch, get_symbol_detail_batch
+
+### v1.2.0 tools (2)
+
+- [Solution Management Tools](tools/solution.md) —
+  list_solutions, switch_solution
 
 ## Anti-Pattern Detectors (19)
 

--- a/docs/architecture/how-it-works.md
+++ b/docs/architecture/how-it-works.md
@@ -10,12 +10,17 @@ provide semantic code navigation. Instead of Claude Code reading entire `.cs` fi
 ## Startup sequence
 
 ```text
-1. MSBuildLocator.RegisterDefaults()    — locate MSBuild SDK
-2. SolutionDiscovery.FindSolutionPath() — BFS for .sln/.slnx (max 3 levels)
-3. Host starts MCP stdio transport      — listens on stdin, responds on stdout
-4. WorkspaceInitializer (background)    — opens MSBuildWorkspace, loads solution
-5. Tools become available               — respond "loading" until workspace is Ready
+1. MSBuildLocator.RegisterDefaults()     — locate MSBuild SDK
+2. SolutionDiscovery.FindSolutionPath()  — BFS for .sln/.slnx
+3. SolutionDiscovery.BfsDiscoverAll()    — collect all solutions
+4. Host starts MCP stdio transport       — stdin/stdout
+5. WorkspaceInitializer (background)     — load solution
+6. Tools become available                — "loading" until Ready
 ```
+
+When multiple solutions are discovered at step 3, the server logs a
+warning and stores the full list. The `list_solutions` and
+`switch_solution` tools allow runtime switching without restart.
 
 ## Solution loading
 
@@ -24,8 +29,19 @@ provide semantic code navigation. Instead of Claude Code reading entire `.cs` fi
 - **Lazy compilation**: For solutions with 50+ projects, compilations are created
   on-demand instead of upfront
 - **LRU cache**: Keeps the 50 most recently used compilations in memory (~250-750 MB)
-- **File watcher**: `.cs` changes trigger incremental text updates; `.csproj` changes
-  trigger full project reload (with 200ms debounce)
+- **File watcher**: `.cs` changes trigger incremental text updates;
+  `.csproj` changes trigger full project reload (with 200ms debounce)
+
+### Solution switching
+
+`ReloadSolutionAsync` disposes the current workspace (watchers,
+compilation cache, MSBuild workspace) and loads a new solution.
+If the new solution fails to load, it attempts to rollback to the
+previous solution. State transitions:
+
+```text
+Ready → Loading → Ready (success) or Error (both loads failed)
+```
 
 ## Tool execution
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -6,7 +6,7 @@ How RoslynLens compares to other Roslyn-based MCP servers.
 
 | Feature | RoslynLens | SharpLensMcp | RoslynMCP | SharpToolsMCP | CodeAnalysisMCP |
 | ------- | ---------- | ------------ | --------- | ------------- | --------------- |
-| **Tools** | 28 | 58 | 5 | ~20 | 3 |
+| **Tools** | 30 | 58 | 5 | ~20 | 3 |
 | **Anti-pattern detectors** | 19 | 0 | 0 | 0 | 0 |
 | **Complexity metrics** | Yes | Yes | Yes | Yes | No |
 | **Data flow analysis** | Yes | Yes | No | No | No |
@@ -20,7 +20,7 @@ How RoslynLens compares to other Roslyn-based MCP servers.
 | **Fuzzy FQN resolution** | Yes | No | No | Yes | No |
 | **External source resolution** | Yes | No | No | Yes | No |
 | **Refactoring tools** | No | Yes (13) | No | Yes (6) | No |
-| **Auto solution discovery** | Yes (BFS) | No | No | No | No |
+| **Auto solution discovery** | Yes (BFS + multi-solution) | No | No | No | No |
 | **Global dotnet tool** | Yes | Yes | No | No | No |
 | **File watcher** | Yes | No | No | No | No |
 | **LRU compilation cache** | Yes (configurable) | Yes | Yes | No | No |

--- a/docs/getting-started/configuration-reference.md
+++ b/docs/getting-started/configuration-reference.md
@@ -83,6 +83,15 @@ Specify the solution explicitly:
 roslyn-lens --solution ./src/Backend/Backend.slnx
 ```
 
+Or let auto-discovery find all solutions and switch at runtime:
+
+```text
+> "List available solutions"     → calls list_solutions
+> "Switch to Frontend.slnx"     → calls switch_solution
+```
+
+See [Solution Management Tools](../tools/solution.md).
+
 ## Logging
 
 All logs go to **stderr** (stdout is reserved for MCP JSON-RPC).

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -34,14 +34,31 @@ Create `.mcp.json` in your project root:
 
 ## Solution discovery
 
-By default, the server finds the nearest `.sln` or `.slnx` file using breadth-first
-search from the current directory (up to 3 levels).
+By default, the server finds the nearest `.sln` or `.slnx` file
+using breadth-first search from the current directory (up to 3
+levels).
 
 To specify a solution explicitly:
 
 ```bash
-claude mcp add --scope user --transport stdio roslyn-lens -- roslyn-lens --solution /path/to/My.slnx
+claude mcp add --scope user --transport stdio roslyn-lens \
+  -- roslyn-lens --solution /path/to/My.slnx
 ```
+
+### Multiple solutions
+
+When multiple `.sln`/`.slnx` files are discovered, the server
+auto-selects the shallowest (then alphabetically first) and logs a
+warning listing all found solutions.
+
+Two MCP tools enable runtime switching without restarting:
+
+- `list_solutions` — lists all discovered solutions with an
+  `IsActive` flag
+- `switch_solution` — reloads the workspace with a different
+  solution (with rollback on failure)
+
+See [Solution Management Tools](../tools/solution.md) for details.
 
 ## Verify connection
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -73,5 +73,5 @@ token consumption on large .NET solutions.
 
 - [Configuration](configuration.md) — MCP registration options, solution
   discovery, environment variables
-- [Tools Reference](../tools/navigation.md) — all 28 tools documented
+- [Tools Reference](../tools/navigation.md) — all 30 tools documented
 - [Anti-Pattern Detectors](../detectors/general.md) — 19 detectors explained

--- a/docs/tools/solution.md
+++ b/docs/tools/solution.md
@@ -1,0 +1,58 @@
+# Solution Management Tools
+
+Tools for working with repositories that contain multiple
+`.sln`/`.slnx` files. At startup, RoslynLens discovers all
+solutions via BFS and auto-selects the shallowest one. These
+tools let you inspect and switch solutions at runtime.
+
+## list_solutions
+
+Lists all discovered solution files with their paths and which
+one is currently loaded.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| *(none)* | | | |
+
+**Example prompt:** "What solutions are available?"
+
+**Returns:**
+
+- `Solutions` — array of `{ Path, Name, IsActive }`
+- `Hint` — contextual message when multiple solutions exist
+  (null when only one solution is found)
+
+Does not require the workspace to be ready (reads static
+discovery state).
+
+---
+
+## switch_solution
+
+Switch the active workspace to a different discovered solution.
+The path must be one returned by `list_solutions`.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `solutionPath` | string | yes | Full path to the target solution |
+
+**Example prompt:** "Switch to Frontend.slnx"
+
+**Behavior:**
+
+1. Validates the path is in the discovered list
+2. Disposes the current workspace (watchers, cache, MSBuild)
+3. Loads the new solution
+4. On failure, attempts to rollback to the previous solution
+
+**Returns on success:**
+
+```json
+{ "status": "switched", "solution": "Frontend.slnx", "projectCount": 12 }
+```
+
+**Returns on error:**
+
+```json
+{ "error": "Failed to switch solution: ...", "state": "Error" }
+```

--- a/src/RoslynLens/Program.cs
+++ b/src/RoslynLens/Program.cs
@@ -10,6 +10,7 @@ MSBuildLocator.RegisterDefaults();
 
 var solutionPath = SolutionDiscovery.FindSolutionPath(args);
 WorkspaceInitializer.SolutionPath = solutionPath;
+WorkspaceInitializer.DiscoveredSolutions = SolutionDiscovery.BfsDiscoverAll(Directory.GetCurrentDirectory());
 
 var config = RoslynLensConfig.FromEnvironment();
 

--- a/src/RoslynLens/Program.cs
+++ b/src/RoslynLens/Program.cs
@@ -10,7 +10,11 @@ MSBuildLocator.RegisterDefaults();
 
 var solutionPath = SolutionDiscovery.FindSolutionPath(args);
 WorkspaceInitializer.SolutionPath = solutionPath;
-WorkspaceInitializer.DiscoveredSolutions = SolutionDiscovery.BfsDiscoverAll(Directory.GetCurrentDirectory());
+
+var discoveryRoot = solutionPath is not null
+    ? Path.GetDirectoryName(Path.GetFullPath(solutionPath))!
+    : Directory.GetCurrentDirectory();
+WorkspaceInitializer.DiscoveredSolutions = SolutionDiscovery.BfsDiscoverAll(discoveryRoot);
 
 var config = RoslynLensConfig.FromEnvironment();
 

--- a/src/RoslynLens/Responses/ToolResponses.cs
+++ b/src/RoslynLens/Responses/ToolResponses.cs
@@ -151,3 +151,7 @@ public record DetailBatchResult(List<DetailBatchItem> Items, int Total, int Succ
 // validate_granit_conventions (Granit-specific)
 public record ConventionViolation(string Category, string Id, string Severity, string Message, string? File, int? Line, string? Suggestion);
 public record GranitConventionsResult(List<ConventionViolation> Violations, int Total, Dictionary<string, int> ByCategory);
+
+// list_solutions
+public record SolutionEntry(string Path, string Name, bool IsActive);
+public record ListSolutionsResult(List<SolutionEntry> Solutions, string? Hint);

--- a/src/RoslynLens/RoslynLens.csproj
+++ b/src/RoslynLens/RoslynLens.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>roslyn-lens</ToolCommandName>
     <PackageId>RoslynLens</PackageId>
-    <Version>1.1.1</Version>
+    <Version>1.2.0</Version>
     <Description>Token-efficient .NET codebase navigation via Roslyn semantic analysis for Claude Code MCP</Description>
     <Authors>Jean-François Meyers</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/RoslynLens/SolutionDiscovery.cs
+++ b/src/RoslynLens/SolutionDiscovery.cs
@@ -6,13 +6,13 @@ namespace RoslynLens;
 /// </summary>
 public static class SolutionDiscovery
 {
-    private static readonly HashSet<string> SkipDirectories = new(StringComparer.OrdinalIgnoreCase)
+    internal static readonly HashSet<string> SkipDirectories = new(StringComparer.OrdinalIgnoreCase)
     {
         ".git", ".vs", ".idea", "node_modules", "bin", "obj",
         "packages", "artifacts", "TestResults", ".claude", "nupkgs"
     };
 
-    private const int MaxBfsDepth = 3;
+    public const int MaxBfsDepth = 3;
 
     public static string? FindSolutionPath(string[] args)
     {

--- a/src/RoslynLens/SolutionDiscovery.cs
+++ b/src/RoslynLens/SolutionDiscovery.cs
@@ -75,6 +75,42 @@ public static class SolutionDiscovery
         return bestMatch;
     }
 
+    public static IReadOnlyList<string> BfsDiscoverAll(string startDirectory)
+    {
+        var queue = new Queue<(string Path, int Depth)>();
+        queue.Enqueue((startDirectory, 0));
+
+        var results = new List<(string FullPath, int Depth)>();
+
+        while (queue.Count > 0)
+        {
+            var (dirPath, depth) = queue.Dequeue();
+
+            if (depth > MaxBfsDepth)
+                continue;
+
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(dirPath).Where(IsSolutionFile))
+                {
+                    results.Add((Path.GetFullPath(file), depth));
+                }
+
+                EnqueueSubDirectories(queue, dirPath, depth);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Skip directories we can't access
+            }
+        }
+
+        return results
+            .OrderBy(r => r.Depth)
+            .ThenBy(r => r.FullPath, StringComparer.OrdinalIgnoreCase)
+            .Select(r => r.FullPath)
+            .ToList();
+    }
+
     private static string? ScanDirectoryForSolution(string dirPath, int depth, string? currentBest, ref int bestDepth)
     {
         foreach (var file in Directory.EnumerateFiles(dirPath).Where(IsSolutionFile))

--- a/src/RoslynLens/Tools/ListSolutionsTool.cs
+++ b/src/RoslynLens/Tools/ListSolutionsTool.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynLens.Responses;
+
+namespace RoslynLens;
+
+[McpServerToolType]
+public static class ListSolutionsTool
+{
+    [McpServerTool(Name = "list_solutions")]
+    [Description("Lists all discovered solution files with their paths and which one is currently active.")]
+    public static Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        CancellationToken ct = default)
+    {
+        var discovered = WorkspaceInitializer.DiscoveredSolutions;
+        var activePath = WorkspaceInitializer.SolutionPath;
+
+        var entries = discovered.Select(path => new SolutionEntry(
+            path,
+            Path.GetFileName(path),
+            string.Equals(path, activePath, StringComparison.OrdinalIgnoreCase)
+        )).ToList();
+
+        var hint = workspace.GetMultiSolutionHint();
+        var result = new ListSolutionsResult(entries, hint);
+
+        return Task.FromResult(Json.Serialize(result));
+    }
+}

--- a/src/RoslynLens/Tools/SwitchSolutionTool.cs
+++ b/src/RoslynLens/Tools/SwitchSolutionTool.cs
@@ -19,8 +19,8 @@ public static class SwitchSolutionTool
         {
             return Json.Serialize(new
             {
-                Error = $"Path not in discovered solutions list. Use list_solutions to see available options.",
-                Discovered = discovered
+                error = "Path not in discovered solutions list. Use list_solutions to see available options.",
+                discovered = discovered
             });
         }
 
@@ -31,17 +31,17 @@ public static class SwitchSolutionTool
 
             return Json.Serialize(new
             {
-                Status = "switched",
-                Solution = Path.GetFileName(solutionPath),
-                ProjectCount = workspace.ProjectCount
+                status = "switched",
+                solution = Path.GetFileName(solutionPath),
+                projectCount = workspace.ProjectCount
             });
         }
         catch (Exception ex)
         {
             return Json.Serialize(new
             {
-                Error = $"Failed to switch solution: {ex.Message}",
-                State = workspace.State.ToString()
+                error = $"Failed to switch solution: {ex.Message}",
+                state = workspace.State.ToString()
             });
         }
     }

--- a/src/RoslynLens/Tools/SwitchSolutionTool.cs
+++ b/src/RoslynLens/Tools/SwitchSolutionTool.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace RoslynLens;
+
+[McpServerToolType]
+public static class SwitchSolutionTool
+{
+    [McpServerTool(Name = "switch_solution")]
+    [Description("Switch to a different solution from the discovered list. Use list_solutions to see available options.")]
+    public static async Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        [Description("Full path to the solution file (must be one of the discovered solutions)")] string solutionPath,
+        CancellationToken ct = default)
+    {
+        var discovered = WorkspaceInitializer.DiscoveredSolutions;
+
+        if (!discovered.Any(p => string.Equals(p, solutionPath, StringComparison.OrdinalIgnoreCase)))
+        {
+            return Json.Serialize(new
+            {
+                Error = $"Path not in discovered solutions list. Use list_solutions to see available options.",
+                Discovered = discovered
+            });
+        }
+
+        try
+        {
+            await workspace.ReloadSolutionAsync(solutionPath, ct);
+            WorkspaceInitializer.SolutionPath = solutionPath;
+
+            return Json.Serialize(new
+            {
+                Status = "switched",
+                Solution = Path.GetFileName(solutionPath),
+                ProjectCount = workspace.ProjectCount
+            });
+        }
+        catch (Exception ex)
+        {
+            return Json.Serialize(new
+            {
+                Error = $"Failed to switch solution: {ex.Message}",
+                State = workspace.State.ToString()
+            });
+        }
+    }
+}

--- a/src/RoslynLens/WorkspaceInitializer.cs
+++ b/src/RoslynLens/WorkspaceInitializer.cs
@@ -16,12 +16,26 @@ public sealed class WorkspaceInitializer(
     /// </summary>
     public static string? SolutionPath { get; set; }
 
+    /// <summary>
+    /// All solution files discovered via BFS. Set by Program.cs before host starts.
+    /// </summary>
+    public static IReadOnlyList<string> DiscoveredSolutions { get; set; } = [];
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (SolutionPath is null)
         {
             logger.LogWarning("No solution file found. Use --solution <path> or run from a directory containing a .sln/.slnx file.");
             return;
+        }
+
+        if (DiscoveredSolutions.Count > 1)
+        {
+            logger.LogWarning(
+                "Multiple solutions discovered ({Count}). Auto-selected: {Selected}. Use list_solutions and switch_solution tools to change. Solutions: {Solutions}",
+                DiscoveredSolutions.Count,
+                SolutionPath,
+                string.Join(", ", DiscoveredSolutions));
         }
 
         if (logger.IsEnabled(LogLevel.Information))

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -65,6 +65,26 @@ public sealed class WorkspaceManager : IDisposable
         }
     }
 
+    public async Task ReloadSolutionAsync(string solutionPath, CancellationToken ct)
+    {
+        DisposeCurrentWorkspace();
+        await LoadSolutionAsync(solutionPath, ct);
+    }
+
+    private void DisposeCurrentWorkspace()
+    {
+        _sourceWatcher?.Dispose();
+        _sourceWatcher = null;
+        _projectWatcher?.Dispose();
+        _projectWatcher = null;
+        _workspace?.Dispose();
+        _workspace = null;
+        _solution = null;
+        _solutionDirectory = null;
+        _compilationCache.Clear();
+        ErrorMessage = null;
+    }
+
     public string? EnsureReadyOrStatus(CancellationToken ct)
     {
         if (State == WorkspaceState.Ready)
@@ -196,9 +216,7 @@ public sealed class WorkspaceManager : IDisposable
 
     public void Dispose()
     {
-        _sourceWatcher?.Dispose();
-        _projectWatcher?.Dispose();
-        _workspace?.Dispose();
+        DisposeCurrentWorkspace();
         _writeLock.Dispose();
     }
 }

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -94,6 +94,15 @@ public sealed class WorkspaceManager : IDisposable
         return Json.Serialize(status);
     }
 
+    public string? GetMultiSolutionHint()
+    {
+        var discovered = WorkspaceInitializer.DiscoveredSolutions;
+        if (discovered.Count <= 1)
+            return null;
+
+        return $"hint: {discovered.Count} solutions discovered. Use list_solutions to see options and switch_solution to change.";
+    }
+
     public Solution? GetSolution() => _solution;
 
     public async Task<Compilation?> GetCompilationAsync(Project project, CancellationToken ct)

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -17,7 +17,7 @@ public sealed class WorkspaceManager : IDisposable
     private readonly ConcurrentDictionary<ProjectId, (Compilation Compilation, long AccessCount)> _compilationCache = new();
     private long _accessCounter;
 
-    private readonly TaskCompletionSource _readySignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TaskCompletionSource _readySignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private MSBuildWorkspace? _workspace;
     private Solution? _solution;
@@ -75,12 +75,37 @@ public sealed class WorkspaceManager : IDisposable
 
     public async Task ReloadSolutionAsync(string solutionPath, CancellationToken ct)
     {
+        var previousPath = _solutionDirectory is not null
+            ? Directory.GetFiles(_solutionDirectory, "*.sln*").FirstOrDefault()
+            : null;
+
         DisposeCurrentWorkspace();
-        await LoadSolutionAsync(solutionPath, ct);
+
+        try
+        {
+            await LoadSolutionAsync(solutionPath, ct);
+        }
+        catch when (previousPath is not null && !string.Equals(previousPath, solutionPath, StringComparison.OrdinalIgnoreCase))
+        {
+            // Reload failed — attempt to restore the previous solution
+            try
+            {
+                await LoadSolutionAsync(previousPath, ct);
+            }
+            catch
+            {
+                // Both loads failed — state is already Error from LoadSolutionAsync
+            }
+
+            throw;
+        }
     }
 
     private void DisposeCurrentWorkspace()
     {
+        State = WorkspaceState.Loading;
+        _readySignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
         _sourceWatcher?.Dispose();
         _sourceWatcher = null;
         _projectWatcher?.Dispose();

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -2,228 +2,211 @@ using Shouldly;
 
 namespace RoslynLens.Tests;
 
-public class SolutionDiscoveryTests
+public class SolutionDiscoveryTests : IDisposable
 {
+    private readonly string _tempDir;
+
+    #region Test plumbing
+
+    /// <summary>
+    /// Initializes a new instance of the SolutionDiscoveryTests class and prepares the test environment.
+    /// </summary>
+    /// <remarks>Creates the temporary directory required for test execution. This constructor is intended for
+    /// use in test setup scenarios.</remarks>
+    public SolutionDiscoveryTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        Console.WriteLine("[SolutionDiscoveryTests] Created temp directory: {0}", _tempDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDir, true);
+            Console.WriteLine("[SolutionDiscoveryTests] Deleted temp directory: {0}", _tempDir);
+        }
+        catch 
+        { 
+        }
+    }
+
+    #endregion
+
+    private string CreateSubDir(string name)
+    {
+        var path = Path.Combine(_tempDir, name);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private string CreateSolutionFile(string relativePath, string? content = null)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath);
+        var dir = Path.GetDirectoryName(fullPath)!;
+        
+        Directory.CreateDirectory(dir);
+
+        if (string.IsNullOrEmpty(content))
+        {
+            content = Path.GetExtension(fullPath) switch {
+                ".slnx" => "<Solution />",
+                ".sln" => """
+                       
+                       Microsoft Visual Studio Solution File, Format Version 12.00
+                       # Visual Studio Version 17
+                       """,
+                _ => ""
+            };
+        }
+
+        File.WriteAllText(fullPath, content);
+        return fullPath;
+    }
+
     [Fact]
     public void FindSolutionPath_With_Explicit_Arg_Returns_Path()
     {
-        // Create a temp directory with a solution file
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        var slnPath = Path.Combine(tempDir, "Test.slnx");
-        File.WriteAllText(slnPath, "<Solution />");
+        var slnPath = CreateSolutionFile("Test.slnx");
 
-        try
-        {
-            var result = SolutionDiscovery.FindSolutionPath(["--solution", slnPath]);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("Test.slnx");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.FindSolutionPath(["--solution", slnPath]);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("Test.slnx");
     }
 
     [Fact]
     public void BfsDiscovery_Finds_Slnx_In_Current_Dir()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        File.WriteAllText(Path.Combine(tempDir, "MyApp.slnx"), "<Solution />");
+        CreateSolutionFile("MyApp.slnx");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("MyApp.slnx");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("MyApp.slnx");
     }
 
     [Fact]
     public void BfsDiscovery_Returns_Null_When_No_Solution()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldBeNull();
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldBeNull();
     }
 
     [Fact]
     public void BfsDiscovery_Finds_Sln_In_Subdirectory()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var subDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(subDir);
-        File.WriteAllText(Path.Combine(subDir, "App.sln"), "");
+        CreateSolutionFile(@"src\App.sln");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("App.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("App.sln");
     }
 
     [Fact]
     public void BfsDiscovery_Prefers_Shallower_Depth()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var subDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(subDir);
-        File.WriteAllText(Path.Combine(tempDir, "Root.sln"), "");
-        File.WriteAllText(Path.Combine(subDir, "Nested.sln"), "");
+        CreateSolutionFile("Root.sln");
+        CreateSolutionFile(@"src\Nested.sln");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldNotBeNull();
-            result.ShouldEndWith("Root.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldNotBeNull();
+        result.ShouldEndWith("Root.sln");
     }
 
     [Fact]
     public void BfsDiscovery_Skips_Known_Directories()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var binDir = Path.Combine(tempDir, "bin");
-        Directory.CreateDirectory(binDir);
-        File.WriteAllText(Path.Combine(binDir, "Hidden.sln"), "");
+        CreateSolutionFile(@"bin\Hidden.sln");
 
-        try
-        {
-            var result = SolutionDiscovery.BfsDiscovery(tempDir);
-            result.ShouldBeNull();
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldBeNull();
     }
 
     [Fact]
-    public void BfsDiscoverAll_Returns_All_Solutions_In_Same_Directory()
+    public void BfsDiscovery_Returns_Null_Beyond_MaxBfsDepth()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-        File.WriteAllText(Path.Combine(tempDir, "SolutionA.slnx"), "<Solution />");
-        File.WriteAllText(Path.Combine(tempDir, "A-Solution.slnx"), "<Solution />");
+        // MaxBfsDepth is 3, so depth 4 should be ignored
+        CreateSolutionFile(@"a\b\c\d\TooDeep.sln");
 
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.Count.ShouldBe(2);
-            results.ShouldContain(p => p.EndsWith("SolutionA.slnx"));
-            results.ShouldContain(p => p.EndsWith("A-Solution.slnx"));
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var result = SolutionDiscovery.BfsDiscovery(_tempDir);
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_ReturnsAllSolutions_InAllDirectories()
+    {
+        CreateSolutionFile("SolutionA.slnx");
+        CreateSolutionFile("A-Solution.slnx");
+        CreateSolutionFile(@"src\Nested.sln");
+
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(3);
+        results.ShouldContain(p => p.EndsWith("SolutionA.slnx"));
+        results.ShouldContain(p => p.EndsWith("A-Solution.slnx"));
+        results.ShouldContain(p => p.EndsWith("Nested.sln"));
     }
 
     [Fact]
     public void BfsDiscoverAll_Orders_By_Depth_Then_Alphabetically()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var subDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(subDir);
-        File.WriteAllText(Path.Combine(tempDir, "Root.sln"), "");
-        File.WriteAllText(Path.Combine(subDir, "Nested.sln"), "");
-        File.WriteAllText(Path.Combine(subDir, "Alpha.sln"), "");
+        CreateSolutionFile("Root.sln");
+        CreateSolutionFile(@"src\Nested.sln");
+        CreateSolutionFile(@"src\Alpha.sln");
 
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.Count.ShouldBe(3);
-            // Depth 0 first, then depth 1 alphabetically
-            results[0].ShouldEndWith("Root.sln");
-            results[1].ShouldEndWith("Alpha.sln");
-            results[2].ShouldEndWith("Nested.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(3);
+        // Depth 0 first, then depth 1 alphabetically
+        results[0].ShouldEndWith("Root.sln");
+        results[1].ShouldEndWith("Alpha.sln");
+        results[2].ShouldEndWith("Nested.sln");
     }
 
     [Fact]
     public void BfsDiscoverAll_Returns_Empty_When_No_Solutions()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
-
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.ShouldBeEmpty();
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.ShouldBeEmpty();
     }
 
     [Fact]
-    public void BfsDiscoverAll_Skips_Known_Directories()
+    public void BfsDiscoverAll_SkipsKnownDirectories()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        var binDir = Path.Combine(tempDir, "bin");
-        var srcDir = Path.Combine(tempDir, "src");
-        Directory.CreateDirectory(binDir);
-        Directory.CreateDirectory(srcDir);
-        File.WriteAllText(Path.Combine(binDir, "Hidden.sln"), "");
-        File.WriteAllText(Path.Combine(srcDir, "Visible.sln"), "");
+        CreateSolutionFile(@"node_modules\skip_me.sln");
+        CreateSolutionFile(@"packages\Nupkg\whatever.slnx");
+        CreateSolutionFile(@"obj\skip_me_too.slnx");
+        CreateSolutionFile(@"src\Visible.sln");
 
-        try
-        {
-            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
-            results.Count.ShouldBe(1);
-            results[0].ShouldEndWith("Visible.sln");
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(1);
+        results[0].ShouldEndWith("Visible.sln");
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Ignores_Solutions_Beyond_MaxBfsDepth()
+    {
+        // MaxBfsDepth is 3, so depth 4 should be ignored
+        CreateSolutionFile("Root.sln");
+        CreateSolutionFile(@"a\b\c\d\TooDeep.slnx");
+
+        var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
+        results.Count.ShouldBe(1);
+        results[0].ShouldEndWith("Root.sln");
     }
 
     [Fact]
     public void FindSolutionPath_Without_Explicit_Arg_Uses_Bfs()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
         var cwd = Directory.GetCurrentDirectory();
 
         try
         {
-            Directory.SetCurrentDirectory(tempDir);
+            Directory.SetCurrentDirectory(_tempDir);
             var result = SolutionDiscovery.FindSolutionPath([]);
             result.ShouldBeNull();
         }
         finally
         {
             Directory.SetCurrentDirectory(cwd);
-            Directory.Delete(tempDir, true);
         }
     }
 }

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -32,8 +32,6 @@ public class SolutionDiscoveryTests : IDisposable
         }
     }
 
-    #endregion
-
     private string CreateSubDir(string name)
     {
         var path = Path.Combine(_tempDir, name);
@@ -64,6 +62,8 @@ public class SolutionDiscoveryTests : IDisposable
         File.WriteAllText(fullPath, content);
         return fullPath;
     }
+
+    #endregion
 
     [Fact]
     public void FindSolutionPath_With_Explicit_Arg_Returns_Path()
@@ -171,6 +171,7 @@ public class SolutionDiscoveryTests : IDisposable
     [Fact]
     public void BfsDiscoverAll_SkipsKnownDirectories()
     {
+        // SolutionDiscovery has a list of ignored directories (e.g. node_modules, obj, bin, packages), so solutions in those should be skipped
         CreateSolutionFile(@"node_modules\skip_me.sln");
         CreateSolutionFile(@"packages\Nupkg\whatever.slnx");
         CreateSolutionFile(@"obj\skip_me_too.slnx");
@@ -184,6 +185,9 @@ public class SolutionDiscoveryTests : IDisposable
     [Fact]
     public void BfsDiscoverAll_Ignores_Solutions_Beyond_MaxBfsDepth()
     {
+        // Sanity check to ensure the constant is what we expect
+        SolutionDiscovery.MaxBfsDepth.ShouldBe(3);
+
         // MaxBfsDepth is 3, so depth 4 should be ignored
         CreateSolutionFile("Root.sln");
         CreateSolutionFile(@"a\b\c\d\TooDeep.slnx");

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -122,6 +122,92 @@ public class SolutionDiscoveryTests
     }
 
     [Fact]
+    public void BfsDiscoverAll_Returns_All_Solutions_In_Same_Directory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "SolutionA.slnx"), "<Solution />");
+        File.WriteAllText(Path.Combine(tempDir, "A-Solution.slnx"), "<Solution />");
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.Count.ShouldBe(2);
+            results.ShouldContain(p => p.EndsWith("SolutionA.slnx"));
+            results.ShouldContain(p => p.EndsWith("A-Solution.slnx"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Orders_By_Depth_Then_Alphabetically()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        var subDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(subDir);
+        File.WriteAllText(Path.Combine(tempDir, "Root.sln"), "");
+        File.WriteAllText(Path.Combine(subDir, "Nested.sln"), "");
+        File.WriteAllText(Path.Combine(subDir, "Alpha.sln"), "");
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.Count.ShouldBe(3);
+            // Depth 0 first, then depth 1 alphabetically
+            results[0].ShouldEndWith("Root.sln");
+            results[1].ShouldEndWith("Alpha.sln");
+            results[2].ShouldEndWith("Nested.sln");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Returns_Empty_When_No_Solutions()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.ShouldBeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void BfsDiscoverAll_Skips_Known_Directories()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");
+        var binDir = Path.Combine(tempDir, "bin");
+        var srcDir = Path.Combine(tempDir, "src");
+        Directory.CreateDirectory(binDir);
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(Path.Combine(binDir, "Hidden.sln"), "");
+        File.WriteAllText(Path.Combine(srcDir, "Visible.sln"), "");
+
+        try
+        {
+            var results = SolutionDiscovery.BfsDiscoverAll(tempDir);
+            results.Count.ShouldBe(1);
+            results[0].ShouldEndWith("Visible.sln");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void FindSolutionPath_Without_Explicit_Arg_Uses_Bfs()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"dd-test-{Guid.NewGuid():N}");

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -95,7 +95,7 @@ public class SolutionDiscoveryTests : IDisposable
     [Fact]
     public void BfsDiscovery_Finds_Sln_In_Subdirectory()
     {
-        CreateSolutionFile(@"src\App.sln");
+        CreateSolutionFile(Path.Combine("src", "App.sln"));
 
         var result = SolutionDiscovery.BfsDiscovery(_tempDir);
         result.ShouldNotBeNull();
@@ -106,7 +106,7 @@ public class SolutionDiscoveryTests : IDisposable
     public void BfsDiscovery_Prefers_Shallower_Depth()
     {
         CreateSolutionFile("Root.sln");
-        CreateSolutionFile(@"src\Nested.sln");
+        CreateSolutionFile(Path.Combine("src", "Nested.sln"));
 
         var result = SolutionDiscovery.BfsDiscovery(_tempDir);
         result.ShouldNotBeNull();
@@ -116,7 +116,7 @@ public class SolutionDiscoveryTests : IDisposable
     [Fact]
     public void BfsDiscovery_Skips_Known_Directories()
     {
-        CreateSolutionFile(@"bin\Hidden.sln");
+        CreateSolutionFile(Path.Combine("bin", "Hidden.sln"));
 
         var result = SolutionDiscovery.BfsDiscovery(_tempDir);
         result.ShouldBeNull();
@@ -126,7 +126,7 @@ public class SolutionDiscoveryTests : IDisposable
     public void BfsDiscovery_Returns_Null_Beyond_MaxBfsDepth()
     {
         // MaxBfsDepth is 3, so depth 4 should be ignored
-        CreateSolutionFile(@"a\b\c\d\TooDeep.sln");
+        CreateSolutionFile(Path.Combine("a", "b", "c", "d", "TooDeep.sln"));
 
         var result = SolutionDiscovery.BfsDiscovery(_tempDir);
         result.ShouldBeNull();
@@ -137,7 +137,7 @@ public class SolutionDiscoveryTests : IDisposable
     {
         CreateSolutionFile("SolutionA.slnx");
         CreateSolutionFile("A-Solution.slnx");
-        CreateSolutionFile(@"src\Nested.sln");
+        CreateSolutionFile(Path.Combine("src", "Nested.sln"));
 
         var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
         results.Count.ShouldBe(3);
@@ -150,8 +150,8 @@ public class SolutionDiscoveryTests : IDisposable
     public void BfsDiscoverAll_Orders_By_Depth_Then_Alphabetically()
     {
         CreateSolutionFile("Root.sln");
-        CreateSolutionFile(@"src\Nested.sln");
-        CreateSolutionFile(@"src\Alpha.sln");
+        CreateSolutionFile(Path.Combine("src", "Nested.sln"));
+        CreateSolutionFile(Path.Combine("src", "Alpha.sln"));
 
         var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
         results.Count.ShouldBe(3);
@@ -172,10 +172,10 @@ public class SolutionDiscoveryTests : IDisposable
     public void BfsDiscoverAll_SkipsKnownDirectories()
     {
         // SolutionDiscovery has a list of ignored directories (e.g. node_modules, obj, bin, packages), so solutions in those should be skipped
-        CreateSolutionFile(@"node_modules\skip_me.sln");
-        CreateSolutionFile(@"packages\Nupkg\whatever.slnx");
-        CreateSolutionFile(@"obj\skip_me_too.slnx");
-        CreateSolutionFile(@"src\Visible.sln");
+        CreateSolutionFile(Path.Combine("node_modules", "skip_me.sln"));
+        CreateSolutionFile(Path.Combine("packages", "Nupkg", "whatever.slnx"));
+        CreateSolutionFile(Path.Combine("obj", "skip_me_too.slnx"));
+        CreateSolutionFile(Path.Combine("src", "Visible.sln"));
 
         var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
         results.Count.ShouldBe(1);
@@ -190,7 +190,7 @@ public class SolutionDiscoveryTests : IDisposable
 
         // MaxBfsDepth is 3, so depth 4 should be ignored
         CreateSolutionFile("Root.sln");
-        CreateSolutionFile(@"a\b\c\d\TooDeep.slnx");
+        CreateSolutionFile(Path.Combine("a", "b", "c", "d", "TooDeep.slnx"));
 
         var results = SolutionDiscovery.BfsDiscoverAll(_tempDir);
         results.Count.ShouldBe(1);

--- a/tests/RoslynLens.Tests/StaticStateCollection.cs
+++ b/tests/RoslynLens.Tests/StaticStateCollection.cs
@@ -1,0 +1,7 @@
+namespace RoslynLens.Tests;
+
+/// <summary>
+/// Tests that mutate WorkspaceInitializer static state must not run in parallel.
+/// </summary>
+[CollectionDefinition("StaticState", DisableParallelization = true)]
+public class StaticStateCollection;

--- a/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
@@ -4,6 +4,7 @@ using Shouldly;
 
 namespace RoslynLens.Tests.Tools;
 
+[Collection("StaticState")]
 public class ListSolutionsToolTests : IDisposable
 {
     private readonly WorkspaceManager _workspace;
@@ -22,12 +23,11 @@ public class ListSolutionsToolTests : IDisposable
 
         try
         {
-            WorkspaceInitializer.DiscoveredSolutions =
-            [
-                @"C:\repos\SolutionA.slnx",
-                @"C:\repos\SolutionB.slnx"
-            ];
-            WorkspaceInitializer.SolutionPath = @"C:\repos\SolutionA.slnx";
+            var pathA = Path.Combine(Path.GetTempPath(), "repos", "SolutionA.slnx");
+            var pathB = Path.Combine(Path.GetTempPath(), "repos", "SolutionB.slnx");
+
+            WorkspaceInitializer.DiscoveredSolutions = [pathA, pathB];
+            WorkspaceInitializer.SolutionPath = pathA;
 
             var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
 
@@ -78,13 +78,12 @@ public class ListSolutionsToolTests : IDisposable
 
         try
         {
-            WorkspaceInitializer.DiscoveredSolutions =
-            [
-                @"C:\repos\A.slnx",
-                @"C:\repos\B.slnx",
-                @"C:\repos\C.slnx"
-            ];
-            WorkspaceInitializer.SolutionPath = @"C:\repos\A.slnx";
+            var pathA = Path.Combine(Path.GetTempPath(), "repos", "A.slnx");
+            var pathB = Path.Combine(Path.GetTempPath(), "repos", "B.slnx");
+            var pathC = Path.Combine(Path.GetTempPath(), "repos", "C.slnx");
+
+            WorkspaceInitializer.DiscoveredSolutions = [pathA, pathB, pathC];
+            WorkspaceInitializer.SolutionPath = pathA;
 
             var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
 

--- a/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace RoslynLens.Tests.Tools;
+
+public class ListSolutionsToolTests : IDisposable
+{
+    private readonly WorkspaceManager _workspace;
+
+    public ListSolutionsToolTests()
+    {
+        var config = new RoslynLensConfig(30, 100, 50, LogLevel.Warning);
+        _workspace = new WorkspaceManager(config);
+    }
+
+    [Fact]
+    public async Task Returns_All_Discovered_Solutions_With_IsActive_Flag()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+        var originalPath = WorkspaceInitializer.SolutionPath;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions =
+            [
+                @"C:\repos\SolutionA.slnx",
+                @"C:\repos\SolutionB.slnx"
+            ];
+            WorkspaceInitializer.SolutionPath = @"C:\repos\SolutionA.slnx";
+
+            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            root.GetProperty("Solutions").GetArrayLength().ShouldBe(2);
+
+            var first = root.GetProperty("Solutions")[0];
+            first.GetProperty("Name").GetString().ShouldBe("SolutionA.slnx");
+            first.GetProperty("IsActive").GetBoolean().ShouldBeTrue();
+
+            var second = root.GetProperty("Solutions")[1];
+            second.GetProperty("Name").GetString().ShouldBe("SolutionB.slnx");
+            second.GetProperty("IsActive").GetBoolean().ShouldBeFalse();
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+            WorkspaceInitializer.SolutionPath = originalPath;
+        }
+    }
+
+    [Fact]
+    public async Task Returns_Empty_When_No_Solutions_Discovered()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = [];
+
+            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("Solutions").GetArrayLength().ShouldBe(0);
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    [Fact]
+    public async Task Includes_Multi_Solution_Hint_When_Multiple_Discovered()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+        var originalPath = WorkspaceInitializer.SolutionPath;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions =
+            [
+                @"C:\repos\A.slnx",
+                @"C:\repos\B.slnx",
+                @"C:\repos\C.slnx"
+            ];
+            WorkspaceInitializer.SolutionPath = @"C:\repos\A.slnx";
+
+            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var hint = doc.RootElement.GetProperty("Hint").GetString();
+            hint.ShouldNotBeNullOrEmpty();
+            hint.ShouldContain("3 solutions discovered");
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+            WorkspaceInitializer.SolutionPath = originalPath;
+        }
+    }
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+    }
+}

--- a/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace RoslynLens.Tests.Tools;
+
+public class SwitchSolutionToolTests : IDisposable
+{
+    private readonly WorkspaceManager _workspace;
+
+    public SwitchSolutionToolTests()
+    {
+        var config = new RoslynLensConfig(30, 100, 50, LogLevel.Warning);
+        _workspace = new WorkspaceManager(config);
+    }
+
+    [Fact]
+    public async Task Rejects_Path_Not_In_Discovered_List()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions =
+            [
+                @"C:\repos\SolutionA.slnx",
+                @"C:\repos\SolutionB.slnx"
+            ];
+
+            var result = await SwitchSolutionTool.ExecuteAsync(
+                _workspace,
+                @"C:\repos\Unknown.slnx",
+                TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var error = doc.RootElement.GetProperty("Error").GetString();
+            error.ShouldNotBeNullOrEmpty();
+            error.ShouldContain("not in discovered");
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    [Fact]
+    public async Task Rejects_When_No_Solutions_Discovered()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = [];
+
+            var result = await SwitchSolutionTool.ExecuteAsync(
+                _workspace,
+                @"C:\repos\Anything.slnx",
+                TestContext.Current.CancellationToken);
+
+            using var doc = JsonDocument.Parse(result);
+            var error = doc.RootElement.GetProperty("Error").GetString();
+            error.ShouldNotBeNullOrEmpty();
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    public void Dispose()
+    {
+        _workspace.Dispose();
+    }
+}

--- a/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
@@ -4,6 +4,7 @@ using Shouldly;
 
 namespace RoslynLens.Tests.Tools;
 
+[Collection("StaticState")]
 public class SwitchSolutionToolTests : IDisposable
 {
     private readonly WorkspaceManager _workspace;
@@ -21,19 +22,19 @@ public class SwitchSolutionToolTests : IDisposable
 
         try
         {
-            WorkspaceInitializer.DiscoveredSolutions =
-            [
-                @"C:\repos\SolutionA.slnx",
-                @"C:\repos\SolutionB.slnx"
-            ];
+            var pathA = Path.Combine(Path.GetTempPath(), "repos", "SolutionA.slnx");
+            var pathB = Path.Combine(Path.GetTempPath(), "repos", "SolutionB.slnx");
+            var unknown = Path.Combine(Path.GetTempPath(), "repos", "Unknown.slnx");
+
+            WorkspaceInitializer.DiscoveredSolutions = [pathA, pathB];
 
             var result = await SwitchSolutionTool.ExecuteAsync(
                 _workspace,
-                @"C:\repos\Unknown.slnx",
+                unknown,
                 TestContext.Current.CancellationToken);
 
             using var doc = JsonDocument.Parse(result);
-            var error = doc.RootElement.GetProperty("Error").GetString();
+            var error = doc.RootElement.GetProperty("error").GetString();
             error.ShouldNotBeNullOrEmpty();
             error.ShouldContain("not in discovered");
         }
@@ -54,11 +55,11 @@ public class SwitchSolutionToolTests : IDisposable
 
             var result = await SwitchSolutionTool.ExecuteAsync(
                 _workspace,
-                @"C:\repos\Anything.slnx",
+                Path.Combine(Path.GetTempPath(), "repos", "Anything.slnx"),
                 TestContext.Current.CancellationToken);
 
             using var doc = JsonDocument.Parse(result);
-            var error = doc.RootElement.GetProperty("Error").GetString();
+            var error = doc.RootElement.GetProperty("error").GetString();
             error.ShouldNotBeNullOrEmpty();
         }
         finally

--- a/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
+++ b/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Logging;
+using Shouldly;
+
+namespace RoslynLens.Tests;
+
+public class WorkspaceManagerTests : IDisposable
+{
+    private readonly WorkspaceManager _manager;
+
+    public WorkspaceManagerTests()
+    {
+        var config = new RoslynLensConfig(30, 100, 50, LogLevel.Warning);
+        _manager = new WorkspaceManager(config);
+    }
+
+    [Fact]
+    public void Initial_State_Is_NotStarted()
+    {
+        _manager.State.ShouldBe(WorkspaceState.NotStarted);
+    }
+
+    [Fact]
+    public async Task ReloadSolutionAsync_Sets_State_To_Loading_Then_Error_For_Invalid_Path()
+    {
+        var ex = await Should.ThrowAsync<Exception>(
+            () => _manager.ReloadSolutionAsync("nonexistent.slnx", TestContext.Current.CancellationToken));
+
+        _manager.State.ShouldBe(WorkspaceState.Error);
+        _manager.ErrorMessage.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ReloadSolutionAsync_Resets_State_From_Ready()
+    {
+        // First load will fail — that's fine, we're testing state transitions
+        try
+        {
+            await _manager.LoadSolutionAsync("nonexistent.slnx", TestContext.Current.CancellationToken);
+        }
+        catch
+        {
+            // Expected
+        }
+
+        _manager.State.ShouldBe(WorkspaceState.Error);
+
+        // Reload should reset state and attempt fresh load
+        try
+        {
+            await _manager.ReloadSolutionAsync("also-nonexistent.slnx", TestContext.Current.CancellationToken);
+        }
+        catch
+        {
+            // Expected
+        }
+
+        // State should be Error (not stuck on old state)
+        _manager.State.ShouldBe(WorkspaceState.Error);
+    }
+
+    public void Dispose()
+    {
+        _manager.Dispose();
+    }
+}

--- a/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
+++ b/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
@@ -30,7 +30,7 @@ public class WorkspaceManagerTests : IDisposable
     }
 
     [Fact]
-    public async Task ReloadSolutionAsync_Resets_State_From_Ready()
+    public async Task ReloadSolutionAsync_Resets_State_After_Previous_Error()
     {
         // First load will fail — that's fine, we're testing state transitions
         try


### PR DESCRIPTION
## Summary

Integrates PR #96 from @ericnewton76 (multi-solution handling) with
review fixes, documentation, and version bump.

### From PR #96 (Eric Newton)

- `list_solutions` and `switch_solution` MCP tools
- `SolutionDiscovery.BfsDiscoverAll()` for multi-solution discovery
- `WorkspaceManager.ReloadSolutionAsync()` with workspace disposal
- `WorkspaceManager.GetMultiSolutionHint()` for contextual hints
- `WorkspaceInitializer.DiscoveredSolutions` static registry
- 9 new tests across 4 test classes

### Review fixes applied

- **Critical**: reset `_readySignal` in `DisposeCurrentWorkspace` to
  prevent stale signal after switch
- **Critical**: set `State = Loading` before disposing fields to
  prevent race condition (`State == Ready` but `_solution == null`)
- **Critical**: rollback to previous solution on reload failure
- Align JSON property casing to camelCase (`error`, `status`)
- Root `BfsDiscoverAll` at resolved solution directory
- Cross-platform test paths (`Path.Combine` instead of backslash)
- `[Collection("StaticState")]` to prevent parallel test flakiness
- Rename misleading test name

### Added

- `docs/tools/solution.md` — new tool documentation page
- Updated tool counts (28 → 30) across all docs
- Multi-solution sections in configuration and architecture docs
- Version bump to 1.2.0 with CHANGELOG entry

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 158 tests pass (including 9 new)
- [x] Markdown lint passes on all modified docs
