### PR TITLE
fix: resolve SonarCloud code smells from multi-solution PR

### DIFF
--- a/src/RoslynLens/Tools/ListSolutionsTool.cs
+++ b/src/RoslynLens/Tools/ListSolutionsTool.cs
@@ -22,7 +22,7 @@ public static class ListSolutionsTool
             string.Equals(path, activePath, StringComparison.OrdinalIgnoreCase)
         )).ToList();
 
-        var hint = workspace.GetMultiSolutionHint();
+        var hint = WorkspaceManager.GetMultiSolutionHint();
         var result = new ListSolutionsResult(entries, hint);
 
         return Task.FromResult(Json.Serialize(result));

--- a/src/RoslynLens/Tools/SwitchSolutionTool.cs
+++ b/src/RoslynLens/Tools/SwitchSolutionTool.cs
@@ -15,7 +15,7 @@ public static class SwitchSolutionTool
     {
         var discovered = WorkspaceInitializer.DiscoveredSolutions;
 
-        if (!discovered.Any(p => string.Equals(p, solutionPath, StringComparison.OrdinalIgnoreCase)))
+        if (!discovered.Contains(solutionPath, StringComparer.OrdinalIgnoreCase))
         {
             return Json.Serialize(new
             {

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -145,7 +145,7 @@ public sealed class WorkspaceManager : IDisposable
         return Json.Serialize(status);
     }
 
-    public string? GetMultiSolutionHint()
+    public static string? GetMultiSolutionHint()
     {
         var discovered = WorkspaceInitializer.DiscoveredSolutions;
         if (discovered.Count <= 1)

--- a/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
+++ b/tests/RoslynLens.Tests/SolutionDiscoveryTests.cs
@@ -25,11 +25,12 @@ public class SolutionDiscoveryTests : IDisposable
         try
         {
             Directory.Delete(_tempDir, true);
-            Console.WriteLine("[SolutionDiscoveryTests] Deleted temp directory: {0}", _tempDir);
         }
-        catch 
-        { 
+        catch
+        {
         }
+
+        GC.SuppressFinalize(this);
     }
 
     private string CreateSubDir(string name)

--- a/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
@@ -102,5 +102,6 @@ public class ListSolutionsToolTests : IDisposable
     public void Dispose()
     {
         _workspace.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/SwitchSolutionToolTests.cs
@@ -71,5 +71,6 @@ public class SwitchSolutionToolTests : IDisposable
     public void Dispose()
     {
         _workspace.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
+++ b/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
@@ -61,5 +61,6 @@ public class WorkspaceManagerTests : IDisposable
     public void Dispose()
     {
         _manager.Dispose();
+        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
## Summary

- Simplify `SwitchSolutionTool` LINQ: `.Any(p => string.Equals(...))` → `.Contains(..., StringComparer.OrdinalIgnoreCase)`
- Make `GetMultiSolutionHint` static (does not access instance data)
- Add `GC.SuppressFinalize(this)` to all 4 `IDisposable` test classes

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 158 tests pass
