### PR TITLE
chore: update all NuGet packages to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-04-14
+
+### Changed
+
+- ModelContextProtocol 1.1.0 → 1.2.0
+- Microsoft.Extensions.Hosting 10.0.5 → 10.0.6
+- Microsoft.Build.Framework 17.11.48 → 18.4.0
+- ICSharpCode.Decompiler 9.1.0.7988 → 10.0.0.8330
+
 ## [1.2.0] - 2026-04-14
 
 ### Added
@@ -98,6 +107,7 @@ Initial release as `JFM.RoslynNavigator`.
 - GitHub Actions CI/CD (build + release + NuGet publish)
 - Global dotnet tool distribution (`dotnet tool install --global JFM.RoslynNavigator`)
 
+[1.2.1]: https://github.com/jfmeyers/roslyn-lens/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/jfmeyers/roslyn-lens/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.0.0...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when multiple solutions are present
 - Startup warning when multiple solutions are discovered
 
+Thanks to [@ericnewton76](https://github.com/ericnewton76) (Eric
+Newton) for the initial implementation (#96).
+
 ## [1.1.1] - 2026-03-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## Stack
 
-.NET 10 | C# 14 | Roslyn 5.3 | ModelContextProtocol 1.1.0 | xUnit v3
+.NET 10 | C# 14 | Roslyn 5.3 | ModelContextProtocol 1.2.0 | xUnit v3
 
 ## Commands
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,16 +4,16 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- MCP SDK -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <!-- Hosting -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
     <!-- Roslyn -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.4.0" />
     <!-- Decompilation -->
-    <PackageVersion Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="10.0.0.8330" />
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ This file lists the third-party libraries used by the **RoslynLens**
 project along with their respective licenses. It is updated whenever an
 external dependency is added or modified.
 
-Last updated: 2026-03-26
+Last updated: 2026-04-14
 
 ---
 
@@ -24,14 +24,14 @@ Last updated: 2026-03-26
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
 | Microsoft.Build.Locator | 1.11.2 | © Microsoft Corporation |
-| Microsoft.Build.Framework | 17.11.48 | © Microsoft Corporation |
+| Microsoft.Build.Framework | 18.4.0 | © Microsoft Corporation |
 | Microsoft.CodeAnalysis.CSharp.Workspaces | 5.3.0 | © Microsoft Corporation |
 | Microsoft.CodeAnalysis.Workspaces.MSBuild | 5.3.0 | © Microsoft Corporation |
-| Microsoft.Extensions.Hosting | 10.0.5 | © Microsoft Corporation |
-| ICSharpCode.Decompiler | 9.1.0.7988 | © Daniel Grunwald and contributors |
+| Microsoft.Extensions.Hosting | 10.0.6 | © Microsoft Corporation |
+| ICSharpCode.Decompiler | 10.0.0.8330 | © Daniel Grunwald and contributors |
 
 ### Apache-2.0
 
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
-| ModelContextProtocol | 1.1.0 | © LF Projects, LLC |
+| ModelContextProtocol | 1.2.0 | © LF Projects, LLC |

--- a/src/RoslynLens/RoslynLens.csproj
+++ b/src/RoslynLens/RoslynLens.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>roslyn-lens</ToolCommandName>
     <PackageId>RoslynLens</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Description>Token-efficient .NET codebase navigation via Roslyn semantic analysis for Claude Code MCP</Description>
     <Authors>Jean-François Meyers</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

- `ModelContextProtocol` 1.1.0 → 1.2.0 (minor)
- `Microsoft.Extensions.Hosting` 10.0.5 → 10.0.6 (patch)
- `Microsoft.Build.Framework` 17.11.48 → 18.4.0 (major)
- `ICSharpCode.Decompiler` 9.1.0.7988 → 10.0.0.8330 (major)
- Updated THIRD-PARTY-NOTICES.md and CLAUDE.md

No vulnerable packages. All licenses unchanged (MIT + Apache-2.0).

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 158 tests pass
- [x] No vulnerable packages
