### PR TITLE
feat: surface multi-solution hint in status + solution-scoped tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-04-14
+
+### Added
+
+- Multi-solution hint surfaced in `EnsureReadyOrStatus` status
+  response (visible during workspace loading)
+- Multi-solution hint surfaced in solution-scoped tool responses:
+  `get_project_graph`, `get_diagnostics` (solution scope),
+  `find_dead_code` (solution scope), `get_test_coverage_map`,
+  `validate_conventions`
+- `WorkspaceManager.SerializeWithMultiSolutionHint<T>()` helper
+  that wraps payloads as `{ result, hint }` only when multiple
+  solutions are discovered (no envelope on single-solution repos)
+
+Addresses [#102](https://github.com/jfmeyers/roslyn-lens/issues/102)
+raised by [@ericnewton76](https://github.com/ericnewton76).
+
 ## [1.2.1] - 2026-04-14
 
 ### Changed
@@ -110,6 +127,7 @@ Initial release as `JFM.RoslynNavigator`.
 - GitHub Actions CI/CD (build + release + NuGet publish)
 - Global dotnet tool distribution (`dotnet tool install --global JFM.RoslynNavigator`)
 
+[1.2.2]: https://github.com/jfmeyers/roslyn-lens/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/jfmeyers/roslyn-lens/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/jfmeyers/roslyn-lens/compare/v1.1.0...v1.1.1

--- a/docs/tools/solution.md
+++ b/docs/tools/solution.md
@@ -56,3 +56,50 @@ The path must be one returned by `list_solutions`.
 ```json
 { "error": "Failed to switch solution: ...", "state": "Error" }
 ```
+
+---
+
+## Hint surfacing in other tools
+
+When multiple solutions are discovered, a contextual hint is also
+surfaced in two additional places so agents organically learn about
+the multi-solution capability without polluting every tool response:
+
+### 1. Workspace status response
+
+While the workspace is loading or in error state, the JSON returned
+by any tool includes a `hint` field:
+
+```json
+{
+  "state": "Loading",
+  "message": "Workspace not ready",
+  "projectCount": 0,
+  "hint": "hint: 2 solutions discovered. Use list_solutions..."
+}
+```
+
+### 2. Solution-scoped tools
+
+The following tools wrap their response as `{ result, hint }` when
+multiple solutions are discovered:
+
+- `get_project_graph`
+- `get_diagnostics` (solution scope only)
+- `find_dead_code` (solution scope only)
+- `get_test_coverage_map`
+- `validate_conventions`
+
+```json
+{
+  "result": { "Projects": [...], "Total": 5 },
+  "hint": "hint: 2 solutions discovered. Use list_solutions..."
+}
+```
+
+On single-solution repos, responses serialize directly (no envelope,
+no hint) to keep token usage minimal.
+
+Token-efficient tools (`find_symbol`, `find_references`, etc.) are
+**not** wrapped — they're called in tight loops and the repeated
+hint would dominate token cost.

--- a/src/RoslynLens/RoslynLens.csproj
+++ b/src/RoslynLens/RoslynLens.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>roslyn-lens</ToolCommandName>
     <PackageId>RoslynLens</PackageId>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Description>Token-efficient .NET codebase navigation via Roslyn semantic analysis for Claude Code MCP</Description>
     <Authors>Jean-François Meyers</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/src/RoslynLens/Tools/FindDeadCodeTool.cs
+++ b/src/RoslynLens/Tools/FindDeadCodeTool.cs
@@ -78,7 +78,9 @@ public static class FindDeadCodeTool
         }
 
         var result = new DeadCodeResult(entries, entries.Count);
-        return Json.Serialize(result);
+        return scope == "solution"
+            ? WorkspaceManager.SerializeWithMultiSolutionHint(result)
+            : Json.Serialize(result);
     }
 
     private static async Task AnalyzeProjectForDeadCodeAsync(

--- a/src/RoslynLens/Tools/GetDiagnosticsTool.cs
+++ b/src/RoslynLens/Tools/GetDiagnosticsTool.cs
@@ -107,7 +107,9 @@ public static class GetDiagnosticsTool
     private static string SerializeResult(List<DiagnosticInfo> diagnostics, string scope)
     {
         var result = new DiagnosticsResult(diagnostics, diagnostics.Count, scope);
-        return Json.Serialize(result);
+        return scope == "solution"
+            ? WorkspaceManager.SerializeWithMultiSolutionHint(result)
+            : Json.Serialize(result);
     }
 
     private static void CollectDiagnostics(

--- a/src/RoslynLens/Tools/GetProjectGraphTool.cs
+++ b/src/RoslynLens/Tools/GetProjectGraphTool.cs
@@ -32,7 +32,7 @@ public static class GetProjectGraphTool
 
         var totalMatching = matchingNames is not null ? matchingNames.Count : allProjects.Count;
         var result = new ProjectGraphResult(nodes, totalMatching);
-        return Task.FromResult(Json.Serialize(result));
+        return Task.FromResult(WorkspaceManager.SerializeWithMultiSolutionHint(result));
     }
 
     private static HashSet<string>? BuildMatchSet(

--- a/src/RoslynLens/Tools/GetTestCoverageMapTool.cs
+++ b/src/RoslynLens/Tools/GetTestCoverageMapTool.cs
@@ -35,7 +35,7 @@ public static class GetTestCoverageMapTool
             workspace, productionProjects, testClassMap, maxResults, ct);
 
         var result = new TestCoverageMapResult(entries, entries.Count, covered, uncovered);
-        return Json.Serialize(result);
+        return WorkspaceManager.SerializeWithMultiSolutionHint(result);
     }
 
     private static async Task<Dictionary<string, (string? File, string Project)>> BuildTestClassMapAsync(

--- a/src/RoslynLens/Tools/ValidateGranitConventionsTool.cs
+++ b/src/RoslynLens/Tools/ValidateGranitConventionsTool.cs
@@ -78,7 +78,7 @@ public static class ValidateGranitConventionsTool
             .ToDictionary(g => g.Key, g => g.Count());
 
         var result = new GranitConventionsResult(violations, violations.Count, byCategory);
-        return Json.Serialize(result);
+        return WorkspaceManager.SerializeWithMultiSolutionHint(result);
     }
 
     private static async Task AnalyzeCompilationAsync(

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -141,7 +141,13 @@ public sealed class WorkspaceManager : IDisposable
                 return null;
         }
 
-        var status = new { state = State.ToString(), message = ErrorMessage ?? "Workspace not ready", projectCount = ProjectCount };
+        var status = new
+        {
+            state = State.ToString(),
+            message = ErrorMessage ?? "Workspace not ready",
+            projectCount = ProjectCount,
+            hint = GetMultiSolutionHint()
+        };
         return Json.Serialize(status);
     }
 
@@ -152,6 +158,20 @@ public sealed class WorkspaceManager : IDisposable
             return null;
 
         return $"hint: {discovered.Count} solutions discovered. Use list_solutions to see options and switch_solution to change.";
+    }
+
+    /// <summary>
+    /// Serializes a tool response with an optional multi-solution hint envelope.
+    /// When multiple solutions are discovered, wraps the payload as { result, hint }.
+    /// Otherwise serializes the payload directly to keep responses minimal.
+    /// </summary>
+    public static string SerializeWithMultiSolutionHint<T>(T payload)
+    {
+        var hint = GetMultiSolutionHint();
+        if (hint is null)
+            return Json.Serialize(payload);
+
+        return Json.Serialize(new { result = payload, hint });
     }
 
     public Solution? GetSolution() => _solution;

--- a/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
+++ b/tests/RoslynLens.Tests/WorkspaceManagerTests.cs
@@ -1,8 +1,10 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Shouldly;
 
 namespace RoslynLens.Tests;
 
+[Collection("StaticState")]
 public class WorkspaceManagerTests : IDisposable
 {
     private readonly WorkspaceManager _manager;
@@ -56,6 +58,98 @@ public class WorkspaceManagerTests : IDisposable
 
         // State should be Error (not stuck on old state)
         _manager.State.ShouldBe(WorkspaceState.Error);
+    }
+
+    [Fact]
+    public void SerializeWithMultiSolutionHint_Returns_Bare_Payload_When_Single_Solution()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = ["/repo/Only.slnx"];
+
+            var payload = new { foo = "bar" };
+            var result = WorkspaceManager.SerializeWithMultiSolutionHint(payload);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("foo").GetString().ShouldBe("bar");
+            doc.RootElement.TryGetProperty("hint", out _).ShouldBeFalse();
+            doc.RootElement.TryGetProperty("result", out _).ShouldBeFalse();
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    [Fact]
+    public void SerializeWithMultiSolutionHint_Wraps_Payload_With_Hint_When_Multiple_Solutions()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = ["/repo/A.slnx", "/repo/B.slnx"];
+
+            var payload = new { foo = "bar" };
+            var result = WorkspaceManager.SerializeWithMultiSolutionHint(payload);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("result").GetProperty("foo").GetString().ShouldBe("bar");
+            var hint = doc.RootElement.GetProperty("hint").GetString();
+            hint.ShouldNotBeNull();
+            hint.ShouldContain("2 solutions discovered");
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    [Fact]
+    public void EnsureReadyOrStatus_Includes_Hint_When_Multiple_Solutions_And_Not_Ready()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = ["/repo/A.slnx", "/repo/B.slnx"];
+
+            // Manager is in NotStarted state — EnsureReadyOrStatus returns the status JSON
+            var result = _manager.EnsureReadyOrStatus(TestContext.Current.CancellationToken);
+
+            result.ShouldNotBeNull();
+            using var doc = JsonDocument.Parse(result);
+            var hint = doc.RootElement.GetProperty("hint").GetString();
+            hint.ShouldNotBeNull();
+            hint.ShouldContain("2 solutions discovered");
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
+    }
+
+    [Fact]
+    public void EnsureReadyOrStatus_Hint_Is_Null_When_Single_Solution()
+    {
+        var original = WorkspaceInitializer.DiscoveredSolutions;
+
+        try
+        {
+            WorkspaceInitializer.DiscoveredSolutions = ["/repo/Only.slnx"];
+
+            var result = _manager.EnsureReadyOrStatus(TestContext.Current.CancellationToken);
+
+            result.ShouldNotBeNull();
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("hint").ValueKind.ShouldBe(JsonValueKind.Null);
+        }
+        finally
+        {
+            WorkspaceInitializer.DiscoveredSolutions = original;
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
Closes #102.

## Summary

Surface the multi-solution hint beyond `list_solutions` so agents discover the capability organically without polluting every tool response.

## Approach: B + A combined

Discussed in #102 — rejected the "hint on every response" approach because it would silently kill the token-economy promise (~30 tokens × hundreds of tool calls per session). Targeted surgical placement instead:

**A — `EnsureReadyOrStatus` status JSON**

Hint added to the status response returned during `Loading`/`Error` states. Catches agents that poll for readiness on first interaction.

**B — Solution-scoped tools**

5 tools where multi-solution confusion actually surfaces ("why am I seeing 5 projects, not 12?"):

- `get_project_graph`
- `get_diagnostics` (solution scope only)
- `find_dead_code` (solution scope only)
- `get_test_coverage_map`
- `validate_conventions`

Token-efficient tools (`find_symbol`, `find_references`, etc.) are **intentionally not modified** — their tight-loop usage would multiply hint tokens to no benefit.

## Implementation

New helper in `WorkspaceManager`:

```csharp
public static string SerializeWithMultiSolutionHint<T>(T payload)
{
    var hint = GetMultiSolutionHint();
    if (hint is null)
        return Json.Serialize(payload);
    return Json.Serialize(new { result = payload, hint });
}
```

Single-solution responses serialize unchanged (no envelope). Multi-solution responses are wrapped as `{ result, hint }`. The 5 tools simply call `WorkspaceManager.SerializeWithMultiSolutionHint(result)` instead of `Json.Serialize(result)`.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 162 tests pass (158 + 4 new)
  - Bare payload returned when single solution
  - Wrapped `{ result, hint }` when multiple solutions
  - `EnsureReadyOrStatus` includes hint when not ready + multi-solution
  - `EnsureReadyOrStatus` hint is null when single solution

## Credits

Thanks to @ericnewton76 for raising the discoverability problem in #96.
