### PR TITLE
fix: resolve SonarCloud code smells (GC.Collect, LINQ, anonymous shorthand)

### DIFF
--- a/src/RoslynLens/Analyzers/InvocationDetectorBase.cs
+++ b/src/RoslynLens/Analyzers/InvocationDetectorBase.cs
@@ -21,21 +21,16 @@ public abstract class InvocationDetectorBase : IAntiPatternDetector
         var root = tree.GetRoot(ct);
         var filePath = tree.FilePath;
 
-        foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        var matches = root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(invocation => TargetExpressions.Contains(invocation.Expression.ToString(), StringComparer.Ordinal));
+
+        foreach (var invocation in matches)
         {
             ct.ThrowIfCancellationRequested();
-
-            var text = invocation.Expression.ToString();
-            foreach (var target in TargetExpressions)
-            {
-                if (string.Equals(text, target, StringComparison.Ordinal))
-                {
-                    var line = invocation.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-                    yield return new AntiPatternViolation(
-                        Id, AntiPatternSeverity.Warning, Message, filePath, line, Suggestion);
-                    break;
-                }
-            }
+            var line = invocation.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+            yield return new AntiPatternViolation(
+                Id, AntiPatternSeverity.Warning, Message, filePath, line, Suggestion);
         }
     }
 }

--- a/src/RoslynLens/Analyzers/ObjectCreationDetectorBase.cs
+++ b/src/RoslynLens/Analyzers/ObjectCreationDetectorBase.cs
@@ -35,13 +35,6 @@ public abstract class ObjectCreationDetectorBase : IAntiPatternDetector
         }
     }
 
-    protected bool IsTargetType(string typeName)
-    {
-        foreach (var target in TargetTypeNames)
-        {
-            if (string.Equals(typeName, target, StringComparison.Ordinal))
-                return true;
-        }
-        return false;
-    }
+    protected bool IsTargetType(string typeName) =>
+        TargetTypeNames.Contains(typeName, StringComparer.Ordinal);
 }

--- a/src/RoslynLens/Tools/SwitchSolutionTool.cs
+++ b/src/RoslynLens/Tools/SwitchSolutionTool.cs
@@ -20,7 +20,7 @@ public static class SwitchSolutionTool
             return Json.Serialize(new
             {
                 error = "Path not in discovered solutions list. Use list_solutions to see available options.",
-                discovered = discovered
+                discovered
             });
         }
 

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -58,9 +58,6 @@ public sealed class WorkspaceManager : IDisposable
 
             SetupFileWatchers();
 
-            // Release temporary MSBuild objects after solution load
-            GC.Collect(2, GCCollectionMode.Optimized, blocking: false);
-
             State = WorkspaceState.Ready;
             _readySignal.TrySetResult();
         }


### PR DESCRIPTION
## Summary

Resolves 4 SonarCloud code smells flagged on `main`:

| # | File | Issue | Severity |
|---|------|-------|----------|
| 1 | `InvocationDetectorBase.cs` L29 | Loops should be simplified using `Where` LINQ | Minor |
| 2 | `ObjectCreationDetectorBase.cs` L40 | Loops should be simplified using `Where` LINQ | Minor |
| 3 | `SwitchSolutionTool.cs` L23 | Member name can be simplified (`discovered = discovered`) | Info |
| 4 | `WorkspaceManager.cs` L62 | Refactor to remove use of `GC.Collect` | **Critical** |

### Notes

- **#4 is the notable one**: removed the manual `GC.Collect(2, ...)` call after `OpenSolutionAsync`. Manual GC calls disrupt runtime heuristics and are considered an antipattern unless backed by profiling data. If memory pressure becomes an issue, the fix should be scoped disposal or weak references — not blunt force GC.
- **#1, #2, #3** are cosmetic simplifications; behavior is preserved.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 158 tests pass
