### PR TITLE
docs: clarify .NET 10 is required for the host, not analyzed projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,13 @@ large .NET solutions.
 
 ## Requirements
 
-- .NET 10 SDK or later
+- .NET 10 SDK or later (to run the tool itself)
 - A .NET solution (`.sln` or `.slnx`)
+
+RoslynLens runs on .NET 10, but analyzes any C# project regardless of its
+target framework (.NET Framework 4.x, .NET Core, .NET 5–10). If your
+solution's `global.json` pins a specific SDK, that SDK must also be
+installed so MSBuild can restore and load it.
 
 ## Installation
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -9,13 +9,17 @@
 
 ### Causes and fixes
 
-**Missing .NET SDK**: RoslynLens requires the same SDK as your solution.
+**Missing .NET SDK**: RoslynLens itself runs on .NET 10, but MSBuild needs
+the SDK declared in your solution's `global.json` to restore and load it.
+List installed SDKs:
 
 ```bash
 dotnet --list-sdks
 ```
 
-Ensure the SDK version matches your `global.json` or `<TargetFramework>`.
+Install any additional SDK your solution requires (the analyzed projects'
+`<TargetFramework>` does not need to match — only the SDK pinned by
+`global.json` must be present).
 
 **MSBuild restore needed**: The solution must be restorable.
 


### PR DESCRIPTION
## Summary

- README's **Requirements** section only mentioned ".NET 10 SDK or later", which can be read as "RoslynLens only analyzes .NET 10 projects". Added a note that the tool runs on .NET 10 but analyzes any TFM (.NET Framework 4.x, .NET Core, .NET 5–10).
- Troubleshooting page incorrectly stated *"RoslynLens requires the same SDK as your solution"*. Replaced with the actual constraint: the SDK pinned by the analyzed solution's `global.json` must be installed so MSBuild can restore/load it.

## Test plan

- [x] `npx markdownlint-cli2` clean on both files
- [ ] Visual review of the rendered README on GitHub