### PR TITLE
docs: add SECURITY, CONTRIBUTING and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (the GitHub
+repository, issues, pull requests, discussions), and also applies when an
+individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at **<jf.meyers@digitaldynamics.be>**.
+
+All complaints will be reviewed and investigated promptly and fairly. The
+maintainer is obligated to respect the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,204 @@
+# Contributing to RoslynLens
+
+Thank you for your interest in contributing! This guide will help you get
+started.
+
+## Code of Conduct
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+We are committed to providing a welcoming and inclusive experience for
+everyone.
+
+## Getting Started
+
+### Prerequisites
+
+- **.NET 10 SDK** — `dotnet --version` should return `10.x`
+  (the [`global.json`](global.json) pins the minimum SDK)
+- **Git** with SSH access
+- *Optional but recommended*: an MCP-capable host (e.g. Claude Code) to
+  exercise the server end-to-end
+
+### Setup
+
+```bash
+git clone git@github.com:jfmeyers/roslyn-lens.git
+cd roslyn-lens
+dotnet restore
+```
+
+### Build and test
+
+```bash
+# Build the solution
+dotnet build
+
+# Run all tests (xUnit v3 + Shouldly)
+dotnet test
+
+# Pack as a global tool and install locally
+dotnet pack -c Release -o ./nupkgs
+dotnet tool install --global --add-source ./nupkgs RoslynLens
+```
+
+## How to Contribute
+
+### Reporting Bugs
+
+Open an issue using the **Bug Report** template. Include:
+
+- A clear, concise description of the problem
+- Steps to reproduce (ideally with a minimal `.sln`)
+- Expected vs actual behavior
+- The MCP tool call that triggered it (name + arguments)
+- `dotnet --info` output and OS
+
+### Suggesting Features
+
+Open an issue using the **Feature Request** template. Describe:
+
+- The use case and motivation
+- Whether it is a new MCP tool, a new anti-pattern detector, or a
+  navigation improvement
+- The expected token cost of the response (RoslynLens aims for
+  30–150 tokens per query)
+- Any alternatives you considered
+
+### Submitting Changes
+
+1. **Fork** the repository
+2. **Create a branch** from `main`:
+
+   ```text
+   <type>/<short-description>
+
+   Types: feature/ | fix/ | docs/ | refactor/ | chore/ | test/ | perf/
+   ```
+
+3. **Write your code** following the conventions below
+4. **Write or update tests** in `tests/RoslynLens.Tests/`
+5. **Run the Definition of Done checks** (see below)
+6. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/):
+
+   ```bash
+   git commit -m "feat(tools): add find_overrides_batch"
+   git commit -m "fix(workspace): handle reload race"
+   git commit -m "docs: clarify multi-solution discovery"
+   ```
+
+7. **Open a pull request** against `main`
+
+### Definition of Done
+
+All checks are **blocking** — a PR will not be merged until they pass:
+
+1. `dotnet build` — zero warnings (`TreatWarningsAsErrors` is enabled)
+2. `dotnet test` — all tests pass
+3. `npx markdownlint-cli2 "<file>"` — every modified `.md` file passes
+4. `dotnet list package --vulnerable --include-transitive` — no known
+   vulnerabilities introduced
+5. Documentation updated if the change affects a public MCP tool, a
+   detector ID, or user-facing behavior
+
+## Code Conventions
+
+### Project layout
+
+| Path | Role |
+| ---- | ---- |
+| `src/RoslynLens/Tools/` | One file per MCP tool |
+| `src/RoslynLens/Analyzers/` | One file per detector (`AP*` general, `GR-*` domain) |
+| `src/RoslynLens/Responses/` | Token-optimized DTOs (records) |
+| `tests/RoslynLens.Tests/` | xUnit v3 + Shouldly, mirrors `src/` layout |
+
+### C# style
+
+- **Target**: `net10.0`, `LangVersion=14`, `Nullable=enable`,
+  `ImplicitUsings=enable`
+- `TreatWarningsAsErrors=true` and `EnforceCodeStyleInBuild=true` —
+  CI will fail on warnings
+- One public type per file
+- Prefer `record` types for DTOs in `Responses/`
+
+### Logging
+
+- **stderr only** — `stdout` is reserved for JSON-RPC (MCP protocol).
+  Never `Console.WriteLine` from production code.
+
+### Token efficiency
+
+RoslynLens exists to reduce token consumption. Every new tool or detector
+must:
+
+- Return the smallest payload that conveys the information
+- Avoid embedding full file contents — return locations + summaries instead
+- Be benchmarked informally against an equivalent `Read` + `Grep`
+  combination in the PR description
+
+### Adding a new detector
+
+See `CLAUDE.md` for the full recipe. Short version:
+
+1. Create `src/RoslynLens/Analyzers/MyDetector.cs`
+   - Simple invocation match (`Foo.Bar()`) → extend `InvocationDetectorBase`
+   - Simple creation match (`new Foo()`) → extend `ObjectCreationDetectorBase`
+   - Otherwise → implement `IAntiPatternDetector` directly
+2. Pick an ID: `APxxx` (general .NET) or `GR-xxx` (domain-specific)
+3. Add a test class in `tests/RoslynLens.Tests/Analyzers/`
+4. Detectors must handle `SemanticModel? model = null` gracefully
+   (syntax-only mode)
+
+### Adding a new tool
+
+See `CLAUDE.md` for the full recipe. Short version:
+
+1. Create `src/RoslynLens/Tools/MyTool.cs` with `[McpServerToolType]`
+2. Tools are auto-discovered via `WithToolsFromAssembly()`
+3. Inject `WorkspaceManager` to access the solution/compilations
+4. Call `workspace.EnsureReadyOrStatus(ct)` — return its status if not ready
+
+### Tests
+
+- **Framework**: xUnit v3 + Shouldly
+- Use `CSharpSyntaxTree.ParseText(source)` — no full compilation needed
+  for most detector tests
+- Use `TestContext.Current.CancellationToken` (never `CancellationToken.None`)
+
+### Dependencies
+
+- When adding, removing, or upgrading a NuGet package, update
+  [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md) at the repository
+  root
+- Non-permissive licenses (GPL, LGPL, AGPL, SSPL) — flag in the PR
+  description before proceeding
+
+### Security
+
+**Never**:
+
+- Commit secrets or credentials (not even in tests or examples)
+- Log to `stdout` (it breaks the MCP protocol)
+- Add a feature that transmits source code over the network
+
+**Always**:
+
+- Treat the analyzed solution as untrusted input — guard against path
+  traversal and resource exhaustion
+- Surface errors as structured MCP responses, never as crashes
+
+## Review Process
+
+A maintainer will review your PR against this checklist:
+
+- [ ] No hardcoded secrets
+- [ ] Tests pass (`dotnet test`)
+- [ ] Build clean (`dotnet build`, zero warnings)
+- [ ] Detector/tool follows the conventions in `CLAUDE.md`
+- [ ] Logs go to stderr, not stdout
+- [ ] `THIRD-PARTY-NOTICES.md` updated (if dependencies changed)
+- [ ] Documentation updated if applicable
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+the [Apache License 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+
+Only the latest published version on
+[NuGet](https://www.nuget.org/packages/RoslynLens/) receives security
+updates. Upgrade with `dotnet tool update --global RoslynLens`.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, send an email to **<jf.meyers@digitaldynamics.be>** with:
+
+- A description of the vulnerability
+- Steps to reproduce (proof of concept if possible)
+- The affected version(s) of `RoslynLens`
+- Any potential impact assessment
+
+### What to expect
+
+- **Acknowledgment** within 48 hours
+- **Status update** within 7 days with an assessment and expected timeline
+- **Fix or mitigation** as soon as reasonably possible, depending on severity
+
+We follow responsible disclosure practices. We ask that you:
+
+- Allow reasonable time to investigate and address the issue before public
+  disclosure
+- Avoid exploiting the vulnerability beyond what is necessary to demonstrate it
+- Do not access or modify other users' data
+
+## Threat Model
+
+RoslynLens is a **local developer tool**. It runs on the developer's machine,
+communicates with the host (typically Claude Code) over `stdio`, and only
+reads the `.sln`/`.slnx`/`.cs` files of solutions the developer explicitly
+opens. It does not expose a network listener, does not collect telemetry, and
+does not transmit source code anywhere.
+
+Areas that are in scope for security reports:
+
+- **Untrusted source code as input** — the tool loads arbitrary C# projects
+  via `MSBuildWorkspace`. Any path traversal, command injection, or
+  arbitrary code execution triggered solely by opening a malicious
+  solution is in scope.
+- **Untrusted MCP requests** — the JSON-RPC layer accepts inputs from the
+  host. Crafted requests must not allow file access outside the loaded
+  workspace, denial-of-service of the host process, or memory exhaustion
+  beyond the documented `ROSLYN_LENS_*` limits.
+- **Dependencies** — vulnerabilities in transitive packages
+  (Roslyn, MSBuild, MCP SDK, ICSharpCode.Decompiler).
+
+Out of scope:
+
+- Issues that require an attacker to already have local code-execution on
+  the developer's machine.
+- MSBuild build-time code execution from analyzers/targets shipped by the
+  analyzed solution itself (this is a property of MSBuild, not RoslynLens).
+
+## Security Design
+
+- **Local-only** — `stdio` transport, no network listener
+- **Read-only** — RoslynLens never writes to the analyzed solution
+- **No secrets stored** — no credentials, no telemetry, no network calls
+  beyond NuGet/SourceLink resolution requested via `resolve_external_source`
+- **Dependency scanning** — automated vulnerability scanning in CI/CD
+  (`dotnet list package --vulnerable` is part of the release checklist)
+
+## Acknowledgments
+
+We appreciate the security research community and will acknowledge reporters
+(with their permission) once the vulnerability is resolved.


### PR DESCRIPTION
## Summary

Add the three standard community files at the repository root, modelled on the Granit repos but adapted to this project (local stdio MCP tool, .NET 10 + xUnit v3 + Shouldly, `main`-branch flow, token-efficiency goal).

- `SECURITY.md` — threat model for a local MCP tool (untrusted `.sln` as input, no network listener), responsible-disclosure contact.
- `CONTRIBUTING.md` — prerequisites, build/test commands, branching, Definition of Done, detector/tool recipes (links to `CLAUDE.md`).
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1.

## Test plan

- [x] `npx markdownlint-cli2` clean on the three files
- [ ] Visual review of the rendered files on GitHub
- [ ] GitHub picks up Security tab + Contributing link on the issue/PR templates