### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug Report
+description: Report a bug in RoslynLens
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Minimal steps to reproduce the behavior. If possible, include the
+        MCP tool call (name + arguments) that triggered it and a minimal
+        `.sln`/`.cs` snippet.
+      placeholder: |
+        1. Open solution '...'
+        2. Call MCP tool 'find_symbol' with arguments '...'
+        3. Observe the error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens instead.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Stack trace
+      description: |
+        Paste any relevant logs from `stderr` or stack traces. Set
+        `ROSLYN_LENS_LOG_LEVEL=Debug` for more verbose output.
+      render: text
+  - type: input
+    id: tool-or-detector
+    attributes:
+      label: Affected MCP tool or detector
+      description: "e.g. `find_references`, `detect_antipatterns` (AP005), `get_project_graph`"
+  - type: input
+    id: roslyn-lens-version
+    attributes:
+      label: RoslynLens version
+      description: "Output of `roslyn-lens --version` or the version installed via `dotnet tool list -g`"
+    validations:
+      required: true
+  - type: input
+    id: dotnet-version
+    attributes:
+      label: .NET SDK version
+      description: "Output of `dotnet --version`"
+    validations:
+      required: true
+  - type: input
+    id: mcp-host
+    attributes:
+      label: MCP host
+      description: "e.g. Claude Code 1.x, custom client, standalone (no host)"
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: "e.g. Ubuntu 24.04, Windows 11, macOS 15"
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical (tool unusable, no workaround)
+        - Major (feature broken, difficult workaround)
+        - Minor (annoying but workable)
+        - Cosmetic (typo, formatting)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/jfmeyers/roslyn-lens/security/policy
+    about: Please report security vulnerabilities responsibly — not via public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a new MCP tool, detector, or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe your idea below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Use case
+      description: What problem does this feature solve? What can a Claude Code user not do today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: |
+        How would you like it to work? If proposing a new MCP tool, sketch
+        the input arguments and the shape of the response.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        Any other approaches you've thought about, including using existing
+        tools like `Read` + `Grep` or combining several existing MCP tools.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of change
+      options:
+        - New MCP tool
+        - New anti-pattern detector
+        - Improvement to an existing tool/detector
+        - Performance / token efficiency
+        - Configuration / discovery
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: token-cost
+    attributes:
+      label: Expected token cost
+      description: |
+        RoslynLens aims for 30–150 tokens per query. Estimate the typical
+        response size for the proposed feature.
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to submit a PR for this feature


### PR DESCRIPTION
## Summary

Add YAML issue templates under `.github/ISSUE_TEMPLATE/`, modelled on the Granit repos but adapted to RoslynLens specifics.

- `bug_report.yml` — captures the affected MCP tool / detector ID, RoslynLens version, .NET SDK version, MCP host, OS, and severity. Hints to set \`ROSLYN_LENS_LOG_LEVEL=Debug\` for stderr logs.
- `feature_request.yml` — categorizes the request (new tool / new detector / improvement / perf / config / docs) and asks for the expected token cost (RoslynLens targets 30–150 tokens per query).
- `config.yml` — disables blank issues and links the security policy. Discussions link omitted because Discussions are not enabled on the repo.

## Test plan

- [ ] Verify the form picker on GitHub shows the two templates plus the security contact link
- [ ] Open a draft issue with each template to confirm validation works