### PR TITLE
docs: link Discussions from issue template picker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/jfmeyers/roslyn-lens/security/policy
     about: Please report security vulnerabilities responsibly — not via public issues.
+  - name: Questions & Discussions
+    url: https://github.com/jfmeyers/roslyn-lens/discussions
+    about: Ask questions, share ideas, or get help from the community.


### PR DESCRIPTION
## Summary

Discussions are now enabled on the repo (\`gh api repos/jfmeyers/roslyn-lens -X PATCH -f has_discussions=true\`), so the issue picker can route questions and ideas there instead of into the bug tracker.

Follow-up to #107, which intentionally omitted the link because Discussions were still disabled at that time.

## Test plan

- [ ] Open the **New issue** form on GitHub and confirm the *Questions & Discussions* contact link appears alongside the security policy link
- [ ] Click the link and confirm it lands on the Discussions tab (not a 404)