### PR TITLE
feat: graph intelligence tools + NuGet bumps (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-06-08
+
+### Added
+
+- `get_communities` — partitions solution namespaces into cohesive communities
+  using label-propagation over the type-reference graph; returns per-community
+  cohesion score (0–1) and common namespace prefix
+- `find_god_nodes` — identifies types or methods whose incoming reference count
+  exceeds mean + N×stddev across the solution; exposes coupling hotspots most
+  likely to benefit from decomposition
+- `find_surprising_dependencies` — scores cross-namespace edges on multiple
+  surprise factors (cross-assembly, peripheral-source, hub-target, semantic
+  distance) and returns the least-expected couplings in the codebase
+- `find_isolated_symbols` — finds types with degree 0 in the full solution
+  graph (no incoming references and no structural outgoing references to other
+  solution types); distinct from `find_dead_code` which only checks incoming
+  references
+
+### Changed
+
+- ModelContextProtocol 1.2.0 → 1.4.0
+- Microsoft.Extensions.Hosting 10.0.6 → 10.0.8
+- Microsoft.Build.Framework 18.4.0 → 18.6.3
+- Microsoft.NET.StringTools 18.6.3 added (new transitive dep of `Microsoft.Build.Framework`,
+  pinned with `ExcludeAssets="runtime"` to satisfy `Microsoft.Build.Locator`)
+- ICSharpCode.Decompiler 10.0.0.8330 → 10.1.0.8386
+- coverlet.collector 8.0.1 → 10.0.1 (test)
+- Microsoft.NET.Test.Sdk 18.3.0 → 18.6.0 (test)
+
 ## [1.2.2] - 2026-04-14
 
 ### Added
@@ -127,6 +156,7 @@ Initial release as `JFM.RoslynNavigator`.
 - GitHub Actions CI/CD (build + release + NuGet publish)
 - Global dotnet tool distribution (`dotnet tool install --global JFM.RoslynNavigator`)
 
+[1.3.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/jfmeyers/roslyn-lens/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/jfmeyers/roslyn-lens/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/jfmeyers/roslyn-lens/compare/v1.1.1...v1.2.0

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,21 +4,22 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- MCP SDK -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <!-- Hosting -->
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <!-- Roslyn -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.6.3" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="18.6.3" />
     <!-- Decompilation -->
-    <PackageVersion Include="ICSharpCode.Decompiler" Version="10.0.0.8330" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="10.1.0.8386" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ large .NET solutions.
 
 ## Features
 
-### 30 Navigation & Analysis Tools
+### 34 Navigation & Analysis Tools
 
 | Tool | Purpose |
 | ---- | ------- |
@@ -26,6 +26,10 @@ large .NET solutions.
 | `find_callers` | Find direct callers of a method |
 | `find_overrides` | Find overrides of virtual/abstract methods |
 | `find_dead_code` | Detect unused types, methods, and properties (with filters) |
+| `find_isolated_symbols` | Detect degree-0 types: no incoming refs and no solution-type deps |
+| `find_god_nodes` | Identify types/methods with disproportionately high in-degree |
+| `find_surprising_dependencies` | Rank unexpected cross-namespace edges by surprise score |
+| `get_communities` | Partition namespaces into cohesive communities (label propagation) |
 | `get_type_hierarchy` | Show inheritance chain, interfaces, and derived types |
 | `get_public_api` | Get public surface without reading the full file |
 | `get_symbol_detail` | Full signature, parameters, return type, and XML docs |
@@ -188,7 +192,7 @@ src/RoslynLens/
 ├── ComplexityAnalyzer.cs       # Cyclomatic/cognitive complexity metrics
 ├── DuplicateCodeDetector.cs    # AST fingerprinting for duplicate detection
 ├── ExternalSourceResolver.cs   # SourceLink + decompilation for NuGet deps
-├── Tools/                      # 30 MCP tool implementations
+├── Tools/                      # 34 MCP tool implementations
 ├── Analyzers/                  # 18 anti-pattern detectors
 └── Responses/                  # Token-optimized DTOs
 ```

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ This file lists the third-party libraries used by the **RoslynLens**
 project along with their respective licenses. It is updated whenever an
 external dependency is added or modified.
 
-Last updated: 2026-04-14
+Last updated: 2026-06-08
 
 ---
 
@@ -12,7 +12,7 @@ Last updated: 2026-04-14
 
 | License | Package count |
 | ------- | ------------- |
-| MIT | 6 |
+| MIT | 7 |
 | Apache-2.0 | 1 |
 
 ---
@@ -24,14 +24,15 @@ Last updated: 2026-04-14
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
 | Microsoft.Build.Locator | 1.11.2 | © Microsoft Corporation |
-| Microsoft.Build.Framework | 18.4.0 | © Microsoft Corporation |
+| Microsoft.Build.Framework | 18.6.3 | © Microsoft Corporation |
+| Microsoft.NET.StringTools | 18.6.3 | © Microsoft Corporation |
 | Microsoft.CodeAnalysis.CSharp.Workspaces | 5.3.0 | © Microsoft Corporation |
 | Microsoft.CodeAnalysis.Workspaces.MSBuild | 5.3.0 | © Microsoft Corporation |
-| Microsoft.Extensions.Hosting | 10.0.6 | © Microsoft Corporation |
-| ICSharpCode.Decompiler | 10.0.0.8330 | © Daniel Grunwald and contributors |
+| Microsoft.Extensions.Hosting | 10.0.8 | © Microsoft Corporation |
+| ICSharpCode.Decompiler | 10.1.0.8386 | © Daniel Grunwald and contributors |
 
 ### Apache-2.0
 
 | Package | Version | Copyright |
 | ------- | ------- | --------- |
-| ModelContextProtocol | 1.2.0 | © LF Projects, LLC |
+| ModelContextProtocol | 1.4.0 | © LF Projects, LLC |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # RoslynLens Documentation
 
 A token-efficient MCP server for .NET codebase navigation via Roslyn.
-30 tools, 19 anti-pattern detectors, configurable and extensible.
+34 tools, 18 anti-pattern detectors, configurable and extensible.
 
 ## Getting Started
 
@@ -13,7 +13,7 @@ A token-efficient MCP server for .NET codebase navigation via Roslyn.
   environment variables, CLI args, tuning guide
 - [Troubleshooting](getting-started/troubleshooting.md) — common issues and fixes
 
-## Tools Reference (30 tools)
+## Tools Reference (34 tools)
 
 ### Core tools (17)
 
@@ -44,12 +44,17 @@ A token-efficient MCP server for .NET codebase navigation via Roslyn.
 - [Solution Management Tools](tools/solution.md) —
   list_solutions, switch_solution
 
-## Anti-Pattern Detectors (19)
+### v1.3.0 tools (4)
+
+- [Graph Intelligence Tools](tools/graph.md) — get_communities,
+  find_god_nodes, find_surprising_dependencies, find_isolated_symbols
+
+## Anti-Pattern Detectors (18)
 
 - [General .NET Detectors](detectors/general.md) — AP001-AP009 (async, error
   handling, resource management, observability)
 - [Domain-Specific Detectors](detectors/domain.md) — GR-GUID, GR-SECRET,
-  GR-DTO, and 7 more
+  GR-DTO, and 6 more
 
 ## Architecture
 

--- a/docs/tools/graph.md
+++ b/docs/tools/graph.md
@@ -1,0 +1,120 @@
+# Graph Intelligence Tools
+
+Four tools that operate on the full solution graph to surface structural
+patterns invisible at the file or symbol level: community clustering,
+coupling hotspots, unexpected edges, and disconnected components.
+
+---
+
+## get_communities
+
+Partition solution namespaces into cohesive communities using
+**label-propagation** over the structural type-reference graph
+(inheritance, field/property types, method signatures).
+Each community is assigned a cohesion score and a common namespace prefix.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `projectFilter` | string | no | Filter by project name (substring match) |
+| `maxIterations` | int | no | Label-propagation iteration cap (default: 20) |
+| `maxResults` | int | no | Max communities to return (default: 30) |
+
+**Example prompts:**
+
+- "Show me the natural namespace clusters in the solution"
+- "Which namespaces belong to the same subsystem?"
+
+**Returns:** Communities ordered by size, each with member namespaces,
+per-namespace degree, cohesion score (0–1), and common prefix.
+
+**Interpreting cohesion:**
+
+| Score | Meaning |
+| ----- | ------- |
+| 0.8–1.0 | Tightly coupled — good internal cohesion |
+| 0.5–0.8 | Moderate — some cross-community leakage |
+| < 0.5 | Loosely coupled — candidates for refactoring |
+
+---
+
+## find_god_nodes
+
+Identify types or methods whose **incoming reference count** is
+disproportionately high relative to the rest of the solution
+(exceeds mean + N × stddev). These are coupling hotspots — worth
+reviewing for decomposition or façade extraction.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `projectFilter` | string | no | Filter by project name (substring match) |
+| `kind` | string | no | `types` (default) or `methods` |
+| `threshold` | float | no | Stddev multiplier for cutoff (default: 2.0) |
+| `minRefs` | int | no | Minimum incoming refs to be a candidate (default: 5) |
+| `maxResults` | int | no | Max results to return (default: 20) |
+
+**Example prompts:**
+
+- "Which types are referenced the most across the solution?"
+- "Find method god nodes in MyApp.Domain" → `kind=methods`
+- "Use a stricter threshold" → `threshold=3.0`
+
+**Returns:** Symbols ranked by incoming reference count, with the
+computed mean, standard deviation, and threshold used.
+
+---
+
+## find_surprising_dependencies
+
+Detect **semantically unexpected** cross-namespace edges — dependencies
+that are structurally present but architecturally surprising. Each edge
+is scored on up to four surprise factors:
+
+| Factor | Score | Condition |
+| ------ | ----- | --------- |
+| `cross-assembly` | +2 | Source and target are in different projects |
+| `peripheral-source` | +2 | Source namespace has very few outgoing deps (outlier) |
+| `hub-target` | +1 | Target namespace is heavily depended upon (above mean+stddev) |
+| `distant-namespaces` | +1 | Namespace prefix distance ≥ 3 segments |
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `projectFilter` | string | no | Filter by project name (substring match) |
+| `maxResults` | int | no | Max dependencies to return (default: 20) |
+
+**Example prompts:**
+
+- "Find unexpected cross-namespace couplings in my solution"
+- "Show surprising dependencies in MyApp.Infrastructure"
+
+**Returns:** Dependencies ranked by surprise score, each with the list
+of triggered factors and the raw reference count.
+
+---
+
+## find_isolated_symbols
+
+Find types with **degree 0** in the full solution graph: no incoming
+references from solution code *and* no structural outgoing references
+to other solution-defined types (inheritance, field/property types,
+method signatures). These are fully disconnected components —
+distinct from `find_dead_code`, which only checks incoming references.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `projectFilter` | string | no | Filter by project name (substring match) |
+| `includePublicTypes` | bool | no | Include public types (default: `false`) |
+| `maxResults` | int | no | Max results to return (default: 50) |
+
+**Example prompts:**
+
+- "Find fully isolated types in MyApp.Shared"
+- "Find isolated internal types across the solution"
+
+**Difference from `find_dead_code`:**
+
+| Tool | In-degree | Out-degree | Typical cause |
+| ---- | --------- | ---------- | ------------- |
+| `find_dead_code` | 0 | any | Unused code that still depends on other types |
+| `find_isolated_symbols` | 0 | 0 | Disconnected stubs, forgotten scaffolding |
+
+**Returns:** Isolated types with kind, file path, line number, and project.

--- a/src/RoslynLens/Responses/ToolResponses.cs
+++ b/src/RoslynLens/Responses/ToolResponses.cs
@@ -155,3 +155,20 @@ public record GranitConventionsResult(List<ConventionViolation> Violations, int 
 // list_solutions
 public record SolutionEntry(string Path, string Name, bool IsActive);
 public record ListSolutionsResult(List<SolutionEntry> Solutions, string? Hint);
+
+// get_communities
+public record CommunityMember(string Namespace, int Degree);
+public record CommunityEntry(string Id, List<CommunityMember> Members, float Cohesion, string? CommonPrefix);
+public record CommunitiesResult(List<CommunityEntry> Communities, int TotalNamespaces, int TotalCommunities);
+
+// find_god_nodes
+public record GodNodeEntry(string Name, string Kind, int IncomingRefs, string? File, int? Line, string? Project);
+public record GodNodesResult(List<GodNodeEntry> Nodes, int Total, double MeanRefs, double StdDevRefs, double Threshold);
+
+// find_surprising_dependencies
+public record SurprisingDependency(string From, string To, int Score, List<string> Reasons, int RefCount);
+public record SurprisingDependenciesResult(List<SurprisingDependency> Dependencies, int Total);
+
+// find_isolated_symbols
+public record IsolatedSymbolEntry(string Name, string Kind, string? File, int? Line, string? Project);
+public record IsolatedSymbolsResult(List<IsolatedSymbolEntry> Symbols, int Total);

--- a/src/RoslynLens/RoslynLens.csproj
+++ b/src/RoslynLens/RoslynLens.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>roslyn-lens</ToolCommandName>
     <PackageId>RoslynLens</PackageId>
-    <Version>1.2.2</Version>
+    <Version>1.3.0</Version>
     <Description>Token-efficient .NET codebase navigation via Roslyn semantic analysis for Claude Code MCP</Description>
     <Authors>Jean-François Meyers</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="ICSharpCode.Decompiler" />
   </ItemGroup>
 

--- a/src/RoslynLens/RoslynLens.csproj
+++ b/src/RoslynLens/RoslynLens.csproj
@@ -34,6 +34,12 @@
     <None Include="../../icon.png" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>RoslynLens.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <!-- Exclude satellite assemblies (Roslyn localization) and legacy BuildHost -->
   <Target Name="RemoveUnneededContent" AfterTargets="Publish">
     <!-- Roslyn diagnostic messages in 13 locales — not needed for an MCP server -->

--- a/src/RoslynLens/Tools/FindGodNodesTool.cs
+++ b/src/RoslynLens/Tools/FindGodNodesTool.cs
@@ -78,25 +78,31 @@ public static class FindGodNodesTool
                 var model = compilation.GetSemanticModel(tree);
                 var root = await tree.GetRootAsync(ct);
 
-                var symbols = CollectSymbols(root, model, kind, ct);
-
-                foreach (var symbol in symbols)
-                {
-                    ct.ThrowIfCancellationRequested();
-                    var key = symbol.ToDisplayString();
-                    if (!seen.Add(key)) continue;
-                    if (IsSystemSymbol(symbol)) continue;
-
-                    var refs = await SymbolFinder.FindReferencesAsync(symbol, solution, ct);
-                    var refCount = refs.Sum(r => r.Locations.Count());
-
-                    var loc = SymbolResolver.GetLocation(symbol);
-                    candidates.Add(new Candidate(key, symbol.Kind.ToString(), refCount, loc.FilePath, loc.Line, project.Name));
-                }
+                foreach (var symbol in CollectSymbols(root, model, kind, ct))
+                    await ProcessSymbolAsync(symbol, solution, project.Name, seen, candidates, ct);
             }
         }
 
         return candidates;
+    }
+
+    private static async Task ProcessSymbolAsync(
+        ISymbol symbol,
+        Solution solution,
+        string projectName,
+        HashSet<string> seen,
+        List<Candidate> candidates,
+        CancellationToken ct)
+    {
+        var key = symbol.ToDisplayString();
+        if (!seen.Add(key)) return;
+        if (IsSystemSymbol(symbol)) return;
+
+        var refs = await SymbolFinder.FindReferencesAsync(symbol, solution, ct);
+        var refCount = refs.Sum(r => r.Locations.Count());
+
+        var loc = SymbolResolver.GetLocation(symbol);
+        candidates.Add(new Candidate(key, symbol.Kind.ToString(), refCount, loc.FilePath, loc.Line, projectName));
     }
 
     private static IEnumerable<ISymbol> CollectSymbols(

--- a/src/RoslynLens/Tools/FindGodNodesTool.cs
+++ b/src/RoslynLens/Tools/FindGodNodesTool.cs
@@ -1,0 +1,130 @@
+using System.ComponentModel;
+using RoslynLens.Responses;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using ModelContextProtocol.Server;
+
+namespace RoslynLens;
+
+[McpServerToolType]
+public static class FindGodNodesTool
+{
+    [McpServerTool(Name = "find_god_nodes")]
+    [Description("Identifies types or methods with disproportionately high incoming reference counts (god nodes). Flags symbols whose reference count exceeds mean + threshold × stddev. These are coupling hotspots worth reviewing for decomposition.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "S107:Methods should not have too many parameters", Justification = "MCP tool parameters are protocol-mandated")]
+    public static async Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        [Description("Optional project name filter (substring match)")] string? projectFilter = null,
+        [Description("Symbol kind to analyze: 'types' or 'methods' (default 'types')")] string kind = "types",
+        [Description("Standard deviation multiplier for god-node threshold (default 2.0)")] double threshold = 2.0,
+        [Description("Minimum incoming references to be considered a candidate (default 5)")] int minRefs = 5,
+        [Description("Maximum number of results to return (default 20)")] int maxResults = 20,
+        CancellationToken ct = default)
+    {
+        var status = workspace.EnsureReadyOrStatus(ct);
+        if (status is not null) return status;
+
+        var solution = workspace.GetSolution();
+        if (solution is null)
+            return Json.Serialize(new { error = "No solution loaded" });
+
+        var projects = solution.Projects
+            .Where(p => projectFilter is null || p.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var candidates = await CollectCandidatesAsync(workspace, solution, projects, kind, ct);
+
+        if (candidates.Count == 0)
+            return Json.Serialize(new GodNodesResult([], 0, 0, 0, 0));
+
+        var refCounts = candidates.Select(c => (double)c.RefCount).ToList();
+        var mean = refCounts.Average();
+        var stdDev = Math.Sqrt(refCounts.Average(x => Math.Pow(x - mean, 2)));
+        var cutoff = mean + threshold * stdDev;
+
+        var godNodes = candidates
+            .Where(c => c.RefCount >= minRefs && c.RefCount >= cutoff)
+            .OrderByDescending(c => c.RefCount)
+            .Take(maxResults)
+            .Select(c => new GodNodeEntry(c.Name, c.Kind, c.RefCount, c.File, c.Line, c.Project))
+            .ToList();
+
+        var result = new GodNodesResult(godNodes, godNodes.Count, mean, stdDev, cutoff);
+        return WorkspaceManager.SerializeWithMultiSolutionHint(result);
+    }
+
+    private sealed record Candidate(string Name, string Kind, int RefCount, string? File, int? Line, string? Project);
+
+    private static async Task<List<Candidate>> CollectCandidatesAsync(
+        WorkspaceManager workspace,
+        Solution solution,
+        List<Project> projects,
+        string kind,
+        CancellationToken ct)
+    {
+        var candidates = new List<Candidate>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            var compilation = await workspace.GetCompilationAsync(project, ct);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                ct.ThrowIfCancellationRequested();
+                var model = compilation.GetSemanticModel(tree);
+                var root = await tree.GetRootAsync(ct);
+
+                var symbols = CollectSymbols(root, model, kind, ct);
+
+                foreach (var symbol in symbols)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var key = symbol.ToDisplayString();
+                    if (!seen.Add(key)) continue;
+                    if (IsSystemSymbol(symbol)) continue;
+
+                    var refs = await SymbolFinder.FindReferencesAsync(symbol, solution, ct);
+                    var refCount = refs.Sum(r => r.Locations.Count());
+
+                    var loc = SymbolResolver.GetLocation(symbol);
+                    candidates.Add(new Candidate(key, symbol.Kind.ToString(), refCount, loc.FilePath, loc.Line, project.Name));
+                }
+            }
+        }
+
+        return candidates;
+    }
+
+    private static IEnumerable<ISymbol> CollectSymbols(
+        SyntaxNode root,
+        SemanticModel model,
+        string kind,
+        CancellationToken ct)
+    {
+        IEnumerable<SyntaxNode> nodes = kind.ToLowerInvariant() switch
+        {
+            "methods" => root.DescendantNodes().OfType<MethodDeclarationSyntax>(),
+            _ => root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+        };
+
+        foreach (var node in nodes)
+        {
+            ct.ThrowIfCancellationRequested();
+            var symbol = model.GetDeclaredSymbol(node, ct);
+            if (symbol is not null)
+                yield return symbol;
+        }
+    }
+
+    private static bool IsSystemSymbol(ISymbol symbol)
+    {
+        var ns = symbol.ContainingNamespace?.ToDisplayString();
+        return ns is not null &&
+               (ns.StartsWith("System", StringComparison.Ordinal) ||
+                ns.StartsWith("Microsoft", StringComparison.Ordinal));
+    }
+}

--- a/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
+++ b/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
@@ -36,9 +36,7 @@ public static class FindIsolatedSymbolsTool
             .Where(p => projectFilter is null || p.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        // Collect all solution type names for outgoing-edge checks
         var solutionTypeNames = await CollectSolutionTypeNamesAsync(workspace, projects, ct);
-
         var isolated = new List<IsolatedSymbolEntry>();
 
         foreach (var project in projects)
@@ -49,46 +47,63 @@ public static class FindIsolatedSymbolsTool
             var compilation = await workspace.GetCompilationAsync(project, ct);
             if (compilation is null) continue;
 
-            foreach (var tree in compilation.SyntaxTrees)
-            {
-                ct.ThrowIfCancellationRequested();
-                if (isolated.Count >= maxResults) break;
-
-                var model = compilation.GetSemanticModel(tree);
-                var root = await tree.GetRootAsync(ct);
-
-                foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
-                {
-                    if (isolated.Count >= maxResults) break;
-                    ct.ThrowIfCancellationRequested();
-
-                    if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
-                    if (IsSystemType(type)) continue;
-                    if (ShouldSkip(type, includePublicTypes)) continue;
-
-                    // Check outgoing structural edges first (cheap — no Roslyn search)
-                    if (HasSolutionTypeReferences(type, solutionTypeNames)) continue;
-
-                    // Check incoming references (expensive — SymbolFinder)
-                    var refs = await SymbolFinder.FindReferencesAsync(type, solution, ct);
-                    var incomingCount = refs.Sum(r => r.Locations.Count());
-                    if (incomingCount > 0) continue;
-
-                    var loc = SymbolResolver.GetLocation(type);
-                    isolated.Add(new IsolatedSymbolEntry(
-                        type.ToDisplayString(),
-                        type.TypeKind.ToString(),
-                        loc.FilePath,
-                        loc.Line,
-                        project.Name));
-                }
-            }
+            await AnalyzeProjectAsync(compilation, project, solution, solutionTypeNames, includePublicTypes, maxResults, isolated, ct);
         }
 
         var result = new IsolatedSymbolsResult(isolated, isolated.Count);
         return solution.Projects.Count() > 1
             ? WorkspaceManager.SerializeWithMultiSolutionHint(result)
             : Json.Serialize(result);
+    }
+
+    private static async Task AnalyzeProjectAsync(
+        Compilation compilation,
+        Project project,
+        Solution solution,
+        HashSet<string> solutionTypeNames,
+        bool includePublicTypes,
+        int maxResults,
+        List<IsolatedSymbolEntry> isolated,
+        CancellationToken ct)
+    {
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (isolated.Count >= maxResults) break;
+
+            var model = compilation.GetSemanticModel(tree);
+            var root = await tree.GetRootAsync(ct);
+
+            await AnalyzeTreeAsync(root, model, project, solution, solutionTypeNames, includePublicTypes, maxResults, isolated, ct);
+        }
+    }
+
+    private static async Task AnalyzeTreeAsync(
+        SyntaxNode root,
+        SemanticModel model,
+        Project project,
+        Solution solution,
+        HashSet<string> solutionTypeNames,
+        bool includePublicTypes,
+        int maxResults,
+        List<IsolatedSymbolEntry> isolated,
+        CancellationToken ct)
+    {
+        foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+        {
+            if (isolated.Count >= maxResults) break;
+            ct.ThrowIfCancellationRequested();
+
+            if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
+            if (IsSystemType(type) || ShouldSkip(type, includePublicTypes)) continue;
+            if (HasSolutionTypeReferences(type, solutionTypeNames)) continue;
+
+            var refs = await SymbolFinder.FindReferencesAsync(type, solution, ct);
+            if (refs.Sum(r => r.Locations.Count()) > 0) continue;
+
+            var loc = SymbolResolver.GetLocation(type);
+            isolated.Add(new IsolatedSymbolEntry(type.ToDisplayString(), type.TypeKind.ToString(), loc.FilePath, loc.Line, project.Name));
+        }
     }
 
     private static async Task<HashSet<string>> CollectSolutionTypeNamesAsync(
@@ -121,41 +136,16 @@ public static class FindIsolatedSymbolsTool
         return names;
     }
 
-    private static bool HasSolutionTypeReferences(INamedTypeSymbol type, HashSet<string> solutionTypes)
-    {
-        if (type.BaseType is not null && solutionTypes.Contains(type.BaseType.ToDisplayString()))
-            return true;
-
-        foreach (var iface in type.Interfaces)
-            if (solutionTypes.Contains(iface.ToDisplayString()))
-                return true;
-
-        foreach (var member in type.GetMembers())
-        {
-            ITypeSymbol? memberType = member switch
-            {
-                IFieldSymbol f => f.Type,
-                IPropertySymbol p => p.Type,
-                _ => null
-            };
-
-            if (memberType is INamedTypeSymbol named && solutionTypes.Contains(named.ToDisplayString()))
-                return true;
-        }
-
-        return false;
-    }
+    private static bool HasSolutionTypeReferences(INamedTypeSymbol type, HashSet<string> solutionTypes) =>
+        TypeStructureHelper.CollectStructuralTypeRefs(type)
+            .Any(t => solutionTypes.Contains(t.ToDisplayString()));
 
     private static bool ShouldSkip(INamedTypeSymbol type, bool includePublicTypes)
     {
-        // Skip compiler-generated, anonymous, and special types
         if (type.IsImplicitlyDeclared || type.IsAnonymousType) return true;
         if (type.TypeKind is TypeKind.Delegate or TypeKind.Enum) return true;
+        if (!includePublicTypes && type.DeclaredAccessibility == Accessibility.Public) return true;
 
-        if (!includePublicTypes && type.DeclaredAccessibility == Accessibility.Public)
-            return true;
-
-        // Skip types decorated with attributes that imply external consumption
         return type.GetAttributes().Any(a =>
             a.AttributeClass?.Name is "McpServerToolTypeAttribute" or "ApiControllerAttribute"
                 or "ControllerAttribute" or "SerializableAttribute");

--- a/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
+++ b/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
@@ -1,0 +1,171 @@
+using System.ComponentModel;
+using RoslynLens.Responses;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using ModelContextProtocol.Server;
+
+namespace RoslynLens;
+
+/// <summary>
+/// Finds symbols with degree 0 in the solution graph — no incoming references from
+/// solution code AND no structural outgoing references to other solution-defined types.
+/// This is distinct from dead code (which has 0 incoming but may still reference other types).
+/// </summary>
+[McpServerToolType]
+public static class FindIsolatedSymbolsTool
+{
+    [McpServerTool(Name = "find_isolated_symbols")]
+    [Description("Finds types with no incoming references from the solution AND no structural dependencies on other solution types (degree 0). These are fully disconnected components — distinct from dead code, which may still reference other types.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "S107:Methods should not have too many parameters", Justification = "MCP tool parameters are protocol-mandated")]
+    public static async Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        [Description("Optional project name filter (substring match)")] string? projectFilter = null,
+        [Description("Include public types in analysis (default false — public types are often consumed externally)")] bool includePublicTypes = false,
+        [Description("Maximum number of results to return (default 50)")] int maxResults = 50,
+        CancellationToken ct = default)
+    {
+        var status = workspace.EnsureReadyOrStatus(ct);
+        if (status is not null) return status;
+
+        var solution = workspace.GetSolution();
+        if (solution is null)
+            return Json.Serialize(new { error = "No solution loaded" });
+
+        var projects = solution.Projects
+            .Where(p => projectFilter is null || p.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        // Collect all solution type names for outgoing-edge checks
+        var solutionTypeNames = await CollectSolutionTypeNamesAsync(workspace, projects, ct);
+
+        var isolated = new List<IsolatedSymbolEntry>();
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (isolated.Count >= maxResults) break;
+
+            var compilation = await workspace.GetCompilationAsync(project, ct);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (isolated.Count >= maxResults) break;
+
+                var model = compilation.GetSemanticModel(tree);
+                var root = await tree.GetRootAsync(ct);
+
+                foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                {
+                    if (isolated.Count >= maxResults) break;
+                    ct.ThrowIfCancellationRequested();
+
+                    if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
+                    if (IsSystemType(type)) continue;
+                    if (ShouldSkip(type, includePublicTypes)) continue;
+
+                    // Check outgoing structural edges first (cheap — no Roslyn search)
+                    if (HasSolutionTypeReferences(type, solutionTypeNames)) continue;
+
+                    // Check incoming references (expensive — SymbolFinder)
+                    var refs = await SymbolFinder.FindReferencesAsync(type, solution, ct);
+                    var incomingCount = refs.Sum(r => r.Locations.Count());
+                    if (incomingCount > 0) continue;
+
+                    var loc = SymbolResolver.GetLocation(type);
+                    isolated.Add(new IsolatedSymbolEntry(
+                        type.ToDisplayString(),
+                        type.TypeKind.ToString(),
+                        loc.FilePath,
+                        loc.Line,
+                        project.Name));
+                }
+            }
+        }
+
+        var result = new IsolatedSymbolsResult(isolated, isolated.Count);
+        return solution.Projects.Count() > 1
+            ? WorkspaceManager.SerializeWithMultiSolutionHint(result)
+            : Json.Serialize(result);
+    }
+
+    private static async Task<HashSet<string>> CollectSolutionTypeNamesAsync(
+        WorkspaceManager workspace,
+        List<Project> projects,
+        CancellationToken ct)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            var compilation = await workspace.GetCompilationAsync(project, ct);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                ct.ThrowIfCancellationRequested();
+                var model = compilation.GetSemanticModel(tree);
+                var root = await tree.GetRootAsync(ct);
+
+                foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                {
+                    if (model.GetDeclaredSymbol(typeDecl, ct) is INamedTypeSymbol type)
+                        names.Add(type.ToDisplayString());
+                }
+            }
+        }
+
+        return names;
+    }
+
+    private static bool HasSolutionTypeReferences(INamedTypeSymbol type, HashSet<string> solutionTypes)
+    {
+        if (type.BaseType is not null && solutionTypes.Contains(type.BaseType.ToDisplayString()))
+            return true;
+
+        foreach (var iface in type.Interfaces)
+            if (solutionTypes.Contains(iface.ToDisplayString()))
+                return true;
+
+        foreach (var member in type.GetMembers())
+        {
+            ITypeSymbol? memberType = member switch
+            {
+                IFieldSymbol f => f.Type,
+                IPropertySymbol p => p.Type,
+                _ => null
+            };
+
+            if (memberType is INamedTypeSymbol named && solutionTypes.Contains(named.ToDisplayString()))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool ShouldSkip(INamedTypeSymbol type, bool includePublicTypes)
+    {
+        // Skip compiler-generated, anonymous, and special types
+        if (type.IsImplicitlyDeclared || type.IsAnonymousType) return true;
+        if (type.TypeKind is TypeKind.Delegate or TypeKind.Enum) return true;
+
+        if (!includePublicTypes && type.DeclaredAccessibility == Accessibility.Public)
+            return true;
+
+        // Skip types decorated with attributes that imply external consumption
+        return type.GetAttributes().Any(a =>
+            a.AttributeClass?.Name is "McpServerToolTypeAttribute" or "ApiControllerAttribute"
+                or "ControllerAttribute" or "SerializableAttribute");
+    }
+
+    private static bool IsSystemType(INamedTypeSymbol type)
+    {
+        var ns = type.ContainingNamespace?.ToDisplayString();
+        return ns is not null &&
+               (ns.StartsWith("System", StringComparison.Ordinal) ||
+                ns.StartsWith("Microsoft", StringComparison.Ordinal));
+    }
+}

--- a/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
+++ b/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
@@ -37,6 +37,7 @@ public static class FindIsolatedSymbolsTool
             .ToList();
 
         var solutionTypeNames = await CollectSolutionTypeNamesAsync(workspace, projects, ct);
+        var ctx = new ScanContext(solution, solutionTypeNames, includePublicTypes, maxResults);
         var isolated = new List<IsolatedSymbolEntry>();
 
         foreach (var project in projects)
@@ -47,7 +48,7 @@ public static class FindIsolatedSymbolsTool
             var compilation = await workspace.GetCompilationAsync(project, ct);
             if (compilation is null) continue;
 
-            await AnalyzeProjectAsync(compilation, project, solution, solutionTypeNames, includePublicTypes, maxResults, isolated, ct);
+            await AnalyzeProjectAsync(compilation, project, ctx, isolated, ct);
         }
 
         var result = new IsolatedSymbolsResult(isolated, isolated.Count);
@@ -56,25 +57,28 @@ public static class FindIsolatedSymbolsTool
             : Json.Serialize(result);
     }
 
+    private sealed record ScanContext(
+        Solution Solution,
+        HashSet<string> SolutionTypeNames,
+        bool IncludePublicTypes,
+        int MaxResults);
+
     private static async Task AnalyzeProjectAsync(
         Compilation compilation,
         Project project,
-        Solution solution,
-        HashSet<string> solutionTypeNames,
-        bool includePublicTypes,
-        int maxResults,
+        ScanContext ctx,
         List<IsolatedSymbolEntry> isolated,
         CancellationToken ct)
     {
         foreach (var tree in compilation.SyntaxTrees)
         {
             ct.ThrowIfCancellationRequested();
-            if (isolated.Count >= maxResults) break;
+            if (isolated.Count >= ctx.MaxResults) break;
 
             var model = compilation.GetSemanticModel(tree);
             var root = await tree.GetRootAsync(ct);
 
-            await AnalyzeTreeAsync(root, model, project, solution, solutionTypeNames, includePublicTypes, maxResults, isolated, ct);
+            await AnalyzeTreeAsync(root, model, project, ctx, isolated, ct);
         }
     }
 
@@ -82,23 +86,20 @@ public static class FindIsolatedSymbolsTool
         SyntaxNode root,
         SemanticModel model,
         Project project,
-        Solution solution,
-        HashSet<string> solutionTypeNames,
-        bool includePublicTypes,
-        int maxResults,
+        ScanContext ctx,
         List<IsolatedSymbolEntry> isolated,
         CancellationToken ct)
     {
         foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
         {
-            if (isolated.Count >= maxResults) break;
+            if (isolated.Count >= ctx.MaxResults) break;
             ct.ThrowIfCancellationRequested();
 
             if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
-            if (IsSystemType(type) || ShouldSkip(type, includePublicTypes)) continue;
-            if (HasSolutionTypeReferences(type, solutionTypeNames)) continue;
+            if (IsSystemType(type) || ShouldSkip(type, ctx.IncludePublicTypes)) continue;
+            if (HasSolutionTypeReferences(type, ctx.SolutionTypeNames)) continue;
 
-            var refs = await SymbolFinder.FindReferencesAsync(type, solution, ct);
+            var refs = await SymbolFinder.FindReferencesAsync(type, ctx.Solution, ct);
             if (refs.Sum(r => r.Locations.Count()) > 0) continue;
 
             var loc = SymbolResolver.GetLocation(type);
@@ -154,8 +155,6 @@ public static class FindIsolatedSymbolsTool
     private static bool IsSystemType(INamedTypeSymbol type)
     {
         var ns = type.ContainingNamespace?.ToDisplayString();
-        return ns is not null &&
-               (ns.StartsWith("System", StringComparison.Ordinal) ||
-                ns.StartsWith("Microsoft", StringComparison.Ordinal));
+        return ns is not null && TypeStructureHelper.IsSystemNamespace(ns);
     }
 }

--- a/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
+++ b/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
@@ -1,0 +1,232 @@
+using System.ComponentModel;
+using RoslynLens.Responses;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using ModelContextProtocol.Server;
+
+namespace RoslynLens;
+
+[McpServerToolType]
+public static class FindSurprisingDependenciesTool
+{
+    [McpServerTool(Name = "find_surprising_dependencies")]
+    [Description("Detects semantically unexpected cross-namespace dependencies: peripheral namespaces reaching hub namespaces, cross-assembly couplings, and structurally distant connections. Scored by surprise factors; returns the most unexpected edges first.")]
+    public static async Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        [Description("Optional project name filter (substring match)")] string? projectFilter = null,
+        [Description("Maximum number of surprising dependencies to return (default 20)")] int maxResults = 20,
+        CancellationToken ct = default)
+    {
+        var status = workspace.EnsureReadyOrStatus(ct);
+        if (status is not null) return status;
+
+        var solution = workspace.GetSolution();
+        if (solution is null)
+            return Json.Serialize(new { error = "No solution loaded" });
+
+        var projects = solution.Projects
+            .Where(p => projectFilter is null || p.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        // Build namespace-level directed graph: (fromNs, toNs) → refCount + fromProject/toProject
+        var edges = new Dictionary<(string From, string To), EdgeData>(EdgeKeyComparer.Instance);
+        var nsToProject = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            var compilation = await workspace.GetCompilationAsync(project, ct);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                ct.ThrowIfCancellationRequested();
+                var model = compilation.GetSemanticModel(tree);
+                var root = await tree.GetRootAsync(ct);
+
+                foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                {
+                    if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
+
+                    var fromNs = type.ContainingNamespace?.ToDisplayString();
+                    if (string.IsNullOrEmpty(fromNs) || IsSystemNamespace(fromNs)) continue;
+
+                    nsToProject.TryAdd(fromNs, project.Name);
+                    CollectOutgoingEdges(type, fromNs, project.Name, edges, nsToProject, ct);
+                }
+            }
+        }
+
+        if (edges.Count == 0)
+            return Json.Serialize(new SurprisingDependenciesResult([], 0));
+
+        var result = ScoreAndRank(edges, nsToProject, maxResults);
+        return WorkspaceManager.SerializeWithMultiSolutionHint(result);
+    }
+
+    private sealed class EdgeData
+    {
+        public int RefCount { get; set; }
+        public string? FromProject { get; set; }
+        public string? ToProject { get; set; }
+    }
+
+    private sealed class EdgeKeyComparer : IEqualityComparer<(string From, string To)>
+    {
+        public static readonly EdgeKeyComparer Instance = new();
+        public bool Equals((string From, string To) x, (string From, string To) y) =>
+            string.Equals(x.From, y.From, StringComparison.Ordinal) &&
+            string.Equals(x.To, y.To, StringComparison.Ordinal);
+        public int GetHashCode((string From, string To) obj) =>
+            HashCode.Combine(obj.From.GetHashCode(StringComparison.Ordinal), obj.To.GetHashCode(StringComparison.Ordinal));
+    }
+
+    private static void CollectOutgoingEdges(
+        INamedTypeSymbol type,
+        string fromNs,
+        string fromProject,
+        Dictionary<(string, string), EdgeData> edges,
+        Dictionary<string, string> nsToProject,
+        CancellationToken ct)
+    {
+        var referencedTypes = new List<ITypeSymbol?>();
+
+        if (type.BaseType is not null) referencedTypes.Add(type.BaseType);
+        foreach (var iface in type.Interfaces) referencedTypes.Add(iface);
+
+        foreach (var member in type.GetMembers())
+        {
+            ct.ThrowIfCancellationRequested();
+            switch (member)
+            {
+                case IFieldSymbol f: referencedTypes.Add(f.Type); break;
+                case IPropertySymbol p: referencedTypes.Add(p.Type); break;
+                case IMethodSymbol m:
+                    referencedTypes.Add(m.ReturnType);
+                    foreach (var param in m.Parameters)
+                        referencedTypes.Add(param.Type);
+                    break;
+            }
+        }
+
+        foreach (var refType in referencedTypes)
+        {
+            if (refType is not INamedTypeSymbol named) continue;
+            var toNs = named.ContainingNamespace?.ToDisplayString();
+            if (string.IsNullOrEmpty(toNs) || IsSystemNamespace(toNs) || toNs == fromNs) continue;
+
+            var toProject = named.ContainingAssembly?.Name ?? toNs;
+            nsToProject.TryAdd(toNs, toProject);
+
+            var key = (fromNs, toNs);
+            if (!edges.TryGetValue(key, out var data))
+            {
+                data = new EdgeData { FromProject = fromProject, ToProject = toProject };
+                edges[key] = data;
+            }
+            data.RefCount++;
+        }
+    }
+
+    private static SurprisingDependenciesResult ScoreAndRank(
+        Dictionary<(string From, string To), EdgeData> edges,
+        Dictionary<string, string> nsToProject,
+        int maxResults)
+    {
+        // Compute degree statistics
+        var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
+        var inDegree = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var (key, _) in edges)
+        {
+            outDegree[key.From] = outDegree.GetValueOrDefault(key.From) + 1;
+            inDegree[key.To] = inDegree.GetValueOrDefault(key.To) + 1;
+        }
+
+        double meanInDegree = inDegree.Count > 0 ? inDegree.Values.Average() : 0;
+        double stdInDegree = inDegree.Count > 0
+            ? Math.Sqrt(inDegree.Values.Average(x => Math.Pow(x - meanInDegree, 2)))
+            : 0;
+        double hubThreshold = meanInDegree + stdInDegree;
+
+        double medianOutDegree = outDegree.Count > 0
+            ? outDegree.Values.OrderBy(x => x).ElementAt(outDegree.Count / 2)
+            : 0;
+
+        var scored = new List<(int Score, List<string> Reasons, string From, string To, int RefCount)>();
+
+        foreach (var (key, data) in edges)
+        {
+            var reasons = new List<string>();
+            var score = 0;
+
+            // Cross-assembly: highest surprise factor
+            var fromProj = nsToProject.GetValueOrDefault(key.From, "");
+            var toProj = nsToProject.GetValueOrDefault(key.To, "");
+            if (!string.Equals(fromProj, toProj, StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrEmpty(fromProj) && !string.IsNullOrEmpty(toProj))
+            {
+                score += 2;
+                reasons.Add($"cross-assembly ({fromProj} → {toProj})");
+            }
+
+            // Peripheral source: source namespace has very few outgoing deps
+            var srcOut = outDegree.GetValueOrDefault(key.From);
+            if (srcOut > 0 && srcOut <= medianOutDegree / 2.0)
+            {
+                score += 2;
+                reasons.Add($"peripheral source ({srcOut} outgoing deps)");
+            }
+
+            // Hub target: target namespace is heavily depended upon
+            var tgtIn = inDegree.GetValueOrDefault(key.To);
+            if (tgtIn > hubThreshold)
+            {
+                score += 1;
+                reasons.Add($"hub target ({tgtIn} incoming deps)");
+            }
+
+            // Semantic distance: short common prefix relative to namespace depth
+            var distance = ComputeNamespaceDistance(key.From, key.To);
+            if (distance >= 3)
+            {
+                score += 1;
+                reasons.Add($"distant namespaces (depth diff {distance})");
+            }
+
+            if (score > 0)
+                scored.Add((score, reasons, key.From, key.To, data.RefCount));
+        }
+
+        var top = scored
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => x.RefCount)
+            .Take(maxResults)
+            .Select(x => new SurprisingDependency(x.From, x.To, x.Score, x.Reasons, x.RefCount))
+            .ToList();
+
+        return new SurprisingDependenciesResult(top, top.Count);
+    }
+
+    private static int ComputeNamespaceDistance(string nsA, string nsB)
+    {
+        var partsA = nsA.Split('.');
+        var partsB = nsB.Split('.');
+        var commonLen = 0;
+        var minLen = Math.Min(partsA.Length, partsB.Length);
+
+        for (var i = 0; i < minLen; i++)
+        {
+            if (string.Equals(partsA[i], partsB[i], StringComparison.Ordinal))
+                commonLen++;
+            else
+                break;
+        }
+
+        return (partsA.Length - commonLen) + (partsB.Length - commonLen);
+    }
+
+    private static bool IsSystemNamespace(string ns) =>
+        ns.StartsWith("System", StringComparison.Ordinal) ||
+        ns.StartsWith("Microsoft", StringComparison.Ordinal);
+}

--- a/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
+++ b/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
@@ -28,34 +28,7 @@ public static class FindSurprisingDependenciesTool
             .Where(p => projectFilter is null || p.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        // Build namespace-level directed graph: (fromNs, toNs) → refCount + fromProject/toProject
-        var edges = new Dictionary<(string From, string To), EdgeData>(EdgeKeyComparer.Instance);
-        var nsToProject = new Dictionary<string, string>(StringComparer.Ordinal);
-
-        foreach (var project in projects)
-        {
-            ct.ThrowIfCancellationRequested();
-            var compilation = await workspace.GetCompilationAsync(project, ct);
-            if (compilation is null) continue;
-
-            foreach (var tree in compilation.SyntaxTrees)
-            {
-                ct.ThrowIfCancellationRequested();
-                var model = compilation.GetSemanticModel(tree);
-                var root = await tree.GetRootAsync(ct);
-
-                foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
-                {
-                    if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
-
-                    var fromNs = type.ContainingNamespace?.ToDisplayString();
-                    if (string.IsNullOrEmpty(fromNs) || IsSystemNamespace(fromNs)) continue;
-
-                    nsToProject.TryAdd(fromNs, project.Name);
-                    CollectOutgoingEdges(type, fromNs, project.Name, edges, nsToProject, ct);
-                }
-            }
-        }
+        var (edges, nsToProject) = await BuildEdgeGraphAsync(workspace, projects, ct);
 
         if (edges.Count == 0)
             return Json.Serialize(new SurprisingDependenciesResult([], 0));
@@ -81,6 +54,61 @@ public static class FindSurprisingDependenciesTool
             HashCode.Combine(obj.From.GetHashCode(StringComparison.Ordinal), obj.To.GetHashCode(StringComparison.Ordinal));
     }
 
+    private static async Task<(Dictionary<(string, string), EdgeData> Edges, Dictionary<string, string> NsToProject)>
+        BuildEdgeGraphAsync(WorkspaceManager workspace, List<Project> projects, CancellationToken ct)
+    {
+        var edges = new Dictionary<(string From, string To), EdgeData>(EdgeKeyComparer.Instance);
+        var nsToProject = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            var compilation = await workspace.GetCompilationAsync(project, ct);
+            if (compilation is null) continue;
+
+            await ScanCompilationAsync(compilation, project.Name, edges, nsToProject, ct);
+        }
+
+        return (edges, nsToProject);
+    }
+
+    private static async Task ScanCompilationAsync(
+        Compilation compilation,
+        string projectName,
+        Dictionary<(string, string), EdgeData> edges,
+        Dictionary<string, string> nsToProject,
+        CancellationToken ct)
+    {
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            ct.ThrowIfCancellationRequested();
+            var model = compilation.GetSemanticModel(tree);
+            var root = await tree.GetRootAsync(ct);
+
+            ScanTreeForEdges(root, model, projectName, edges, nsToProject, ct);
+        }
+    }
+
+    private static void ScanTreeForEdges(
+        SyntaxNode root,
+        SemanticModel model,
+        string projectName,
+        Dictionary<(string, string), EdgeData> edges,
+        Dictionary<string, string> nsToProject,
+        CancellationToken ct)
+    {
+        foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+        {
+            if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
+
+            var fromNs = type.ContainingNamespace?.ToDisplayString();
+            if (string.IsNullOrEmpty(fromNs) || IsSystemNamespace(fromNs)) continue;
+
+            nsToProject.TryAdd(fromNs, projectName);
+            CollectOutgoingEdges(type, fromNs, projectName, edges, nsToProject, ct);
+        }
+    }
+
     private static void CollectOutgoingEdges(
         INamedTypeSymbol type,
         string fromNs,
@@ -89,33 +117,12 @@ public static class FindSurprisingDependenciesTool
         Dictionary<string, string> nsToProject,
         CancellationToken ct)
     {
-        var referencedTypes = new List<ITypeSymbol?>();
-
-        if (type.BaseType is not null) referencedTypes.Add(type.BaseType);
-        foreach (var iface in type.Interfaces) referencedTypes.Add(iface);
-
-        foreach (var member in type.GetMembers())
+        foreach (var targetType in TypeStructureHelper.CollectStructuralTypeRefs(type, ct))
         {
-            ct.ThrowIfCancellationRequested();
-            switch (member)
-            {
-                case IFieldSymbol f: referencedTypes.Add(f.Type); break;
-                case IPropertySymbol p: referencedTypes.Add(p.Type); break;
-                case IMethodSymbol m:
-                    referencedTypes.Add(m.ReturnType);
-                    foreach (var param in m.Parameters)
-                        referencedTypes.Add(param.Type);
-                    break;
-            }
-        }
-
-        foreach (var refType in referencedTypes)
-        {
-            if (refType is not INamedTypeSymbol named) continue;
-            var toNs = named.ContainingNamespace?.ToDisplayString();
+            var toNs = targetType.ContainingNamespace?.ToDisplayString();
             if (string.IsNullOrEmpty(toNs) || IsSystemNamespace(toNs) || toNs == fromNs) continue;
 
-            var toProject = named.ContainingAssembly?.Name ?? toNs;
+            var toProject = targetType.ContainingAssembly?.Name ?? toNs;
             nsToProject.TryAdd(toNs, toProject);
 
             var key = (fromNs, toNs);
@@ -133,7 +140,6 @@ public static class FindSurprisingDependenciesTool
         Dictionary<string, string> nsToProject,
         int maxResults)
     {
-        // Compute degree statistics
         var outDegree = new Dictionary<string, int>(StringComparer.Ordinal);
         var inDegree = new Dictionary<string, int>(StringComparer.Ordinal);
 
@@ -157,43 +163,7 @@ public static class FindSurprisingDependenciesTool
 
         foreach (var (key, data) in edges)
         {
-            var reasons = new List<string>();
-            var score = 0;
-
-            // Cross-assembly: highest surprise factor
-            var fromProj = nsToProject.GetValueOrDefault(key.From, "");
-            var toProj = nsToProject.GetValueOrDefault(key.To, "");
-            if (!string.Equals(fromProj, toProj, StringComparison.OrdinalIgnoreCase) &&
-                !string.IsNullOrEmpty(fromProj) && !string.IsNullOrEmpty(toProj))
-            {
-                score += 2;
-                reasons.Add($"cross-assembly ({fromProj} → {toProj})");
-            }
-
-            // Peripheral source: source namespace has very few outgoing deps
-            var srcOut = outDegree.GetValueOrDefault(key.From);
-            if (srcOut > 0 && srcOut <= medianOutDegree / 2.0)
-            {
-                score += 2;
-                reasons.Add($"peripheral source ({srcOut} outgoing deps)");
-            }
-
-            // Hub target: target namespace is heavily depended upon
-            var tgtIn = inDegree.GetValueOrDefault(key.To);
-            if (tgtIn > hubThreshold)
-            {
-                score += 1;
-                reasons.Add($"hub target ({tgtIn} incoming deps)");
-            }
-
-            // Semantic distance: short common prefix relative to namespace depth
-            var distance = ComputeNamespaceDistance(key.From, key.To);
-            if (distance >= 3)
-            {
-                score += 1;
-                reasons.Add($"distant namespaces (depth diff {distance})");
-            }
-
+            var (score, reasons) = ComputeSurpriseScore(key, data, outDegree, inDegree, nsToProject, hubThreshold, medianOutDegree);
             if (score > 0)
                 scored.Add((score, reasons, key.From, key.To, data.RefCount));
         }
@@ -206,6 +176,51 @@ public static class FindSurprisingDependenciesTool
             .ToList();
 
         return new SurprisingDependenciesResult(top, top.Count);
+    }
+
+    private static (int Score, List<string> Reasons) ComputeSurpriseScore(
+        (string From, string To) key,
+        EdgeData data,
+        Dictionary<string, int> outDegree,
+        Dictionary<string, int> inDegree,
+        Dictionary<string, string> nsToProject,
+        double hubThreshold,
+        double medianOutDegree)
+    {
+        var reasons = new List<string>();
+        var score = 0;
+
+        var fromProj = nsToProject.GetValueOrDefault(key.From, "");
+        var toProj = nsToProject.GetValueOrDefault(key.To, "");
+        if (!string.Equals(fromProj, toProj, StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrEmpty(fromProj) && !string.IsNullOrEmpty(toProj))
+        {
+            score += 2;
+            reasons.Add($"cross-assembly ({fromProj} → {toProj})");
+        }
+
+        var srcOut = outDegree.GetValueOrDefault(key.From);
+        if (srcOut > 0 && srcOut <= medianOutDegree / 2.0)
+        {
+            score += 2;
+            reasons.Add($"peripheral source ({srcOut} outgoing deps)");
+        }
+
+        var tgtIn = inDegree.GetValueOrDefault(key.To);
+        if (tgtIn > hubThreshold)
+        {
+            score += 1;
+            reasons.Add($"hub target ({tgtIn} incoming deps)");
+        }
+
+        var distance = ComputeNamespaceDistance(key.From, key.To);
+        if (distance >= 3)
+        {
+            score += 1;
+            reasons.Add($"distant namespaces (depth diff {distance})");
+        }
+
+        return (score, reasons);
     }
 
     private static int ComputeNamespaceDistance(string nsA, string nsB)

--- a/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
+++ b/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
@@ -102,7 +102,7 @@ public static class FindSurprisingDependenciesTool
             if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
 
             var fromNs = type.ContainingNamespace?.ToDisplayString();
-            if (string.IsNullOrEmpty(fromNs) || IsSystemNamespace(fromNs)) continue;
+            if (string.IsNullOrEmpty(fromNs) || TypeStructureHelper.IsSystemNamespace(fromNs)) continue;
 
             nsToProject.TryAdd(fromNs, projectName);
             CollectOutgoingEdges(type, fromNs, projectName, edges, nsToProject, ct);
@@ -120,7 +120,7 @@ public static class FindSurprisingDependenciesTool
         foreach (var targetType in TypeStructureHelper.CollectStructuralTypeRefs(type, ct))
         {
             var toNs = targetType.ContainingNamespace?.ToDisplayString();
-            if (string.IsNullOrEmpty(toNs) || IsSystemNamespace(toNs) || toNs == fromNs) continue;
+            if (string.IsNullOrEmpty(toNs) || TypeStructureHelper.IsSystemNamespace(toNs) || toNs == fromNs) continue;
 
             var toProject = targetType.ContainingAssembly?.Name ?? toNs;
             nsToProject.TryAdd(toNs, toProject);
@@ -163,7 +163,7 @@ public static class FindSurprisingDependenciesTool
 
         foreach (var (key, data) in edges)
         {
-            var (score, reasons) = ComputeSurpriseScore(key, data, outDegree, inDegree, nsToProject, hubThreshold, medianOutDegree);
+            var (score, reasons) = ComputeSurpriseScore(key, outDegree, inDegree, nsToProject, hubThreshold, medianOutDegree);
             if (score > 0)
                 scored.Add((score, reasons, key.From, key.To, data.RefCount));
         }
@@ -180,7 +180,6 @@ public static class FindSurprisingDependenciesTool
 
     private static (int Score, List<string> Reasons) ComputeSurpriseScore(
         (string From, string To) key,
-        EdgeData data,
         Dictionary<string, int> outDegree,
         Dictionary<string, int> inDegree,
         Dictionary<string, string> nsToProject,
@@ -241,7 +240,4 @@ public static class FindSurprisingDependenciesTool
         return (partsA.Length - commonLen) + (partsB.Length - commonLen);
     }
 
-    private static bool IsSystemNamespace(string ns) =>
-        ns.StartsWith("System", StringComparison.Ordinal) ||
-        ns.StartsWith("Microsoft", StringComparison.Ordinal);
 }

--- a/src/RoslynLens/Tools/GetCommunitiesTool.cs
+++ b/src/RoslynLens/Tools/GetCommunitiesTool.cs
@@ -28,38 +28,7 @@ public static class GetCommunitiesTool
         var projects = solution.Projects
             .Where(p => projectFilter is null || p.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase));
 
-        // Build namespace → namespace weighted adjacency (undirected)
-        var nsEdges = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
-        var nsProjects = new Dictionary<string, string>(StringComparer.Ordinal);
-
-        foreach (var project in projects)
-        {
-            ct.ThrowIfCancellationRequested();
-            var compilation = await workspace.GetCompilationAsync(project, ct);
-            if (compilation is null) continue;
-
-            foreach (var tree in compilation.SyntaxTrees)
-            {
-                ct.ThrowIfCancellationRequested();
-                var model = compilation.GetSemanticModel(tree);
-                var root = await tree.GetRootAsync(ct);
-
-                foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
-                {
-                    if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
-
-                    var sourceNs = type.ContainingNamespace?.ToDisplayString();
-                    if (string.IsNullOrEmpty(sourceNs) || IsSystemNamespace(sourceNs)) continue;
-
-                    if (!nsEdges.ContainsKey(sourceNs))
-                        nsEdges[sourceNs] = new Dictionary<string, int>(StringComparer.Ordinal);
-
-                    nsProjects.TryAdd(sourceNs, project.Name);
-
-                    CollectTypeReferences(type, sourceNs, nsEdges, ct);
-                }
-            }
-        }
+        var nsEdges = await BuildNamespaceGraphAsync(workspace, projects, ct);
 
         if (nsEdges.Count == 0)
             return Json.Serialize(new CommunitiesResult([], 0, 0));
@@ -71,39 +40,57 @@ public static class GetCommunitiesTool
         return WorkspaceManager.SerializeWithMultiSolutionHint(result);
     }
 
-    private static void CollectTypeReferences(
-        INamedTypeSymbol type,
-        string sourceNs,
+    private static async Task<Dictionary<string, Dictionary<string, int>>> BuildNamespaceGraphAsync(
+        WorkspaceManager workspace,
+        IEnumerable<Project> projects,
+        CancellationToken ct)
+    {
+        var nsEdges = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            var compilation = await workspace.GetCompilationAsync(project, ct);
+            if (compilation is null) continue;
+
+            await ScanCompilationAsync(compilation, nsEdges, ct);
+        }
+
+        return nsEdges;
+    }
+
+    private static async Task ScanCompilationAsync(
+        Compilation compilation,
         Dictionary<string, Dictionary<string, int>> nsEdges,
         CancellationToken ct)
     {
-        var referencedTypes = new List<ITypeSymbol?>();
-
-        if (type.BaseType is not null)
-            referencedTypes.Add(type.BaseType);
-
-        foreach (var iface in type.Interfaces)
-            referencedTypes.Add(iface);
-
-        foreach (var member in type.GetMembers())
+        foreach (var tree in compilation.SyntaxTrees)
         {
             ct.ThrowIfCancellationRequested();
-            switch (member)
-            {
-                case IFieldSymbol f: referencedTypes.Add(f.Type); break;
-                case IPropertySymbol p: referencedTypes.Add(p.Type); break;
-                case IMethodSymbol m:
-                    referencedTypes.Add(m.ReturnType);
-                    foreach (var param in m.Parameters)
-                        referencedTypes.Add(param.Type);
-                    break;
-            }
-        }
+            var model = compilation.GetSemanticModel(tree);
+            var root = await tree.GetRootAsync(ct);
 
-        foreach (var refType in referencedTypes)
+            foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                RegisterTypeEdges(typeDecl, model, nsEdges, ct);
+        }
+    }
+
+    private static void RegisterTypeEdges(
+        TypeDeclarationSyntax typeDecl,
+        SemanticModel model,
+        Dictionary<string, Dictionary<string, int>> nsEdges,
+        CancellationToken ct)
+    {
+        if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) return;
+
+        var sourceNs = type.ContainingNamespace?.ToDisplayString();
+        if (string.IsNullOrEmpty(sourceNs) || IsSystemNamespace(sourceNs)) return;
+
+        nsEdges.TryAdd(sourceNs, new Dictionary<string, int>(StringComparer.Ordinal));
+
+        foreach (var targetType in TypeStructureHelper.CollectStructuralTypeRefs(type, ct))
         {
-            if (refType is not INamedTypeSymbol named) continue;
-            var targetNs = named.ContainingNamespace?.ToDisplayString();
+            var targetNs = targetType.ContainingNamespace?.ToDisplayString();
             if (string.IsNullOrEmpty(targetNs) || IsSystemNamespace(targetNs) || targetNs == sourceNs)
                 continue;
 
@@ -183,18 +170,16 @@ public static class GetCommunitiesTool
             var memberList = members
                 .Select(ns =>
                 {
-                    var degree = graph.TryGetValue(ns, out var neighbors)
-                        ? neighbors.Count
-                        : 0;
+                    var degree = graph.TryGetValue(ns, out var neighbors) ? neighbors.Count : 0;
                     return new CommunityMember(ns, degree);
                 })
                 .OrderByDescending(m => m.Degree)
                 .ToList();
 
-            var cohesion = ComputeCohesion(members, graph);
-            var commonPrefix = FindCommonPrefix(members);
-
-            entries.Add(new CommunityEntry(group.Key, memberList, cohesion, commonPrefix));
+            entries.Add(new CommunityEntry(
+                group.Key, memberList,
+                ComputeCohesion(members, graph),
+                FindCommonPrefix(members)));
         }
 
         return entries;
@@ -225,10 +210,7 @@ public static class GetCommunitiesTool
 
     private static string? FindCommonPrefix(IEnumerable<string> namespaces)
     {
-        var parts = namespaces
-            .Select(ns => ns.Split('.'))
-            .ToList();
-
+        var parts = namespaces.Select(ns => ns.Split('.')).ToList();
         if (parts.Count == 0) return null;
 
         var prefix = new List<string>();

--- a/src/RoslynLens/Tools/GetCommunitiesTool.cs
+++ b/src/RoslynLens/Tools/GetCommunitiesTool.cs
@@ -1,0 +1,252 @@
+using System.ComponentModel;
+using RoslynLens.Responses;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using ModelContextProtocol.Server;
+
+namespace RoslynLens;
+
+[McpServerToolType]
+public static class GetCommunitiesTool
+{
+    [McpServerTool(Name = "get_communities")]
+    [Description("Partitions solution namespaces into cohesive communities via label-propagation over the type-reference graph. Returns each community with a cohesion score (0–1) and common namespace prefix.")]
+    public static async Task<string> ExecuteAsync(
+        WorkspaceManager workspace,
+        [Description("Optional project name filter (substring match)")] string? projectFilter = null,
+        [Description("Maximum label-propagation iterations (default 20)")] int maxIterations = 20,
+        [Description("Maximum number of communities to return (default 30)")] int maxResults = 30,
+        CancellationToken ct = default)
+    {
+        var status = workspace.EnsureReadyOrStatus(ct);
+        if (status is not null) return status;
+
+        var solution = workspace.GetSolution();
+        if (solution is null)
+            return Json.Serialize(new { error = "No solution loaded" });
+
+        var projects = solution.Projects
+            .Where(p => projectFilter is null || p.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase));
+
+        // Build namespace → namespace weighted adjacency (undirected)
+        var nsEdges = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
+        var nsProjects = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var project in projects)
+        {
+            ct.ThrowIfCancellationRequested();
+            var compilation = await workspace.GetCompilationAsync(project, ct);
+            if (compilation is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                ct.ThrowIfCancellationRequested();
+                var model = compilation.GetSemanticModel(tree);
+                var root = await tree.GetRootAsync(ct);
+
+                foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                {
+                    if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) continue;
+
+                    var sourceNs = type.ContainingNamespace?.ToDisplayString();
+                    if (string.IsNullOrEmpty(sourceNs) || IsSystemNamespace(sourceNs)) continue;
+
+                    if (!nsEdges.ContainsKey(sourceNs))
+                        nsEdges[sourceNs] = new Dictionary<string, int>(StringComparer.Ordinal);
+
+                    nsProjects.TryAdd(sourceNs, project.Name);
+
+                    CollectTypeReferences(type, sourceNs, nsEdges, ct);
+                }
+            }
+        }
+
+        if (nsEdges.Count == 0)
+            return Json.Serialize(new CommunitiesResult([], 0, 0));
+
+        var communities = RunLabelPropagation(nsEdges, maxIterations, ct);
+        var entries = BuildCommunityEntries(communities, nsEdges, maxResults);
+
+        var result = new CommunitiesResult(entries, nsEdges.Count, entries.Count);
+        return WorkspaceManager.SerializeWithMultiSolutionHint(result);
+    }
+
+    private static void CollectTypeReferences(
+        INamedTypeSymbol type,
+        string sourceNs,
+        Dictionary<string, Dictionary<string, int>> nsEdges,
+        CancellationToken ct)
+    {
+        var referencedTypes = new List<ITypeSymbol?>();
+
+        if (type.BaseType is not null)
+            referencedTypes.Add(type.BaseType);
+
+        foreach (var iface in type.Interfaces)
+            referencedTypes.Add(iface);
+
+        foreach (var member in type.GetMembers())
+        {
+            ct.ThrowIfCancellationRequested();
+            switch (member)
+            {
+                case IFieldSymbol f: referencedTypes.Add(f.Type); break;
+                case IPropertySymbol p: referencedTypes.Add(p.Type); break;
+                case IMethodSymbol m:
+                    referencedTypes.Add(m.ReturnType);
+                    foreach (var param in m.Parameters)
+                        referencedTypes.Add(param.Type);
+                    break;
+            }
+        }
+
+        foreach (var refType in referencedTypes)
+        {
+            if (refType is not INamedTypeSymbol named) continue;
+            var targetNs = named.ContainingNamespace?.ToDisplayString();
+            if (string.IsNullOrEmpty(targetNs) || IsSystemNamespace(targetNs) || targetNs == sourceNs)
+                continue;
+
+            AddEdge(nsEdges, sourceNs, targetNs);
+            AddEdge(nsEdges, targetNs, sourceNs);
+        }
+    }
+
+    private static void AddEdge(
+        Dictionary<string, Dictionary<string, int>> graph,
+        string from, string to)
+    {
+        if (!graph.TryGetValue(from, out var neighbors))
+        {
+            neighbors = new Dictionary<string, int>(StringComparer.Ordinal);
+            graph[from] = neighbors;
+        }
+        neighbors[to] = neighbors.GetValueOrDefault(to) + 1;
+    }
+
+    private static Dictionary<string, string> RunLabelPropagation(
+        Dictionary<string, Dictionary<string, int>> graph,
+        int maxIterations,
+        CancellationToken ct)
+    {
+        var labels = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var ns in graph.Keys)
+            labels[ns] = ns;
+
+        for (var iter = 0; iter < maxIterations; iter++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var changed = false;
+
+            foreach (var ns in graph.Keys.OrderBy(x => x, StringComparer.Ordinal))
+            {
+                var neighbors = graph[ns];
+                if (neighbors.Count == 0) continue;
+
+                var labelWeights = new Dictionary<string, double>(StringComparer.Ordinal);
+                foreach (var (neighbor, weight) in neighbors)
+                {
+                    var label = labels.TryGetValue(neighbor, out var l) ? l : neighbor;
+                    labelWeights[label] = labelWeights.GetValueOrDefault(label) + weight;
+                }
+
+                var bestLabel = labelWeights.MaxBy(kv => kv.Value).Key;
+                if (bestLabel != labels[ns])
+                {
+                    labels[ns] = bestLabel;
+                    changed = true;
+                }
+            }
+
+            if (!changed) break;
+        }
+
+        return labels;
+    }
+
+    private static List<CommunityEntry> BuildCommunityEntries(
+        Dictionary<string, string> labels,
+        Dictionary<string, Dictionary<string, int>> graph,
+        int maxResults)
+    {
+        var groups = labels
+            .GroupBy(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal)
+            .OrderByDescending(g => g.Count())
+            .Take(maxResults);
+
+        var entries = new List<CommunityEntry>();
+
+        foreach (var group in groups)
+        {
+            var members = group.ToHashSet(StringComparer.Ordinal);
+
+            var memberList = members
+                .Select(ns =>
+                {
+                    var degree = graph.TryGetValue(ns, out var neighbors)
+                        ? neighbors.Count
+                        : 0;
+                    return new CommunityMember(ns, degree);
+                })
+                .OrderByDescending(m => m.Degree)
+                .ToList();
+
+            var cohesion = ComputeCohesion(members, graph);
+            var commonPrefix = FindCommonPrefix(members);
+
+            entries.Add(new CommunityEntry(group.Key, memberList, cohesion, commonPrefix));
+        }
+
+        return entries;
+    }
+
+    private static float ComputeCohesion(
+        HashSet<string> members,
+        Dictionary<string, Dictionary<string, int>> graph)
+    {
+        if (members.Count <= 1) return 1.0f;
+
+        var intraEdges = 0;
+        var totalEdges = 0;
+
+        foreach (var ns in members)
+        {
+            if (!graph.TryGetValue(ns, out var neighbors)) continue;
+            foreach (var (neighbor, _) in neighbors)
+            {
+                totalEdges++;
+                if (members.Contains(neighbor))
+                    intraEdges++;
+            }
+        }
+
+        return totalEdges == 0 ? 0f : (float)intraEdges / totalEdges;
+    }
+
+    private static string? FindCommonPrefix(IEnumerable<string> namespaces)
+    {
+        var parts = namespaces
+            .Select(ns => ns.Split('.'))
+            .ToList();
+
+        if (parts.Count == 0) return null;
+
+        var prefix = new List<string>();
+        var minLen = parts.Min(p => p.Length);
+
+        for (var i = 0; i < minLen; i++)
+        {
+            var segment = parts[0][i];
+            if (parts.All(p => string.Equals(p[i], segment, StringComparison.Ordinal)))
+                prefix.Add(segment);
+            else
+                break;
+        }
+
+        return prefix.Count > 0 ? string.Join(".", prefix) : null;
+    }
+
+    private static bool IsSystemNamespace(string ns) =>
+        ns.StartsWith("System", StringComparison.Ordinal) ||
+        ns.StartsWith("Microsoft", StringComparison.Ordinal);
+}

--- a/src/RoslynLens/Tools/GetCommunitiesTool.cs
+++ b/src/RoslynLens/Tools/GetCommunitiesTool.cs
@@ -84,14 +84,14 @@ public static class GetCommunitiesTool
         if (model.GetDeclaredSymbol(typeDecl, ct) is not INamedTypeSymbol type) return;
 
         var sourceNs = type.ContainingNamespace?.ToDisplayString();
-        if (string.IsNullOrEmpty(sourceNs) || IsSystemNamespace(sourceNs)) return;
+        if (string.IsNullOrEmpty(sourceNs) || TypeStructureHelper.IsSystemNamespace(sourceNs)) return;
 
         nsEdges.TryAdd(sourceNs, new Dictionary<string, int>(StringComparer.Ordinal));
 
         foreach (var targetType in TypeStructureHelper.CollectStructuralTypeRefs(type, ct))
         {
             var targetNs = targetType.ContainingNamespace?.ToDisplayString();
-            if (string.IsNullOrEmpty(targetNs) || IsSystemNamespace(targetNs) || targetNs == sourceNs)
+            if (string.IsNullOrEmpty(targetNs) || TypeStructureHelper.IsSystemNamespace(targetNs) || targetNs == sourceNs)
                 continue;
 
             AddEdge(nsEdges, sourceNs, targetNs);
@@ -228,7 +228,4 @@ public static class GetCommunitiesTool
         return prefix.Count > 0 ? string.Join(".", prefix) : null;
     }
 
-    private static bool IsSystemNamespace(string ns) =>
-        ns.StartsWith("System", StringComparison.Ordinal) ||
-        ns.StartsWith("Microsoft", StringComparison.Ordinal);
 }

--- a/src/RoslynLens/TypeStructureHelper.cs
+++ b/src/RoslynLens/TypeStructureHelper.cs
@@ -1,0 +1,39 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynLens;
+
+internal static class TypeStructureHelper
+{
+    /// <summary>
+    /// Yields all named types structurally referenced by a type:
+    /// base type, interfaces, field/property types, method return types, and parameter types.
+    /// </summary>
+    internal static IEnumerable<INamedTypeSymbol> CollectStructuralTypeRefs(
+        INamedTypeSymbol type, CancellationToken ct = default)
+    {
+        if (type.BaseType is not null)
+            yield return type.BaseType;
+
+        foreach (var iface in type.Interfaces)
+            yield return iface;
+
+        foreach (var member in type.GetMembers())
+        {
+            ct.ThrowIfCancellationRequested();
+            switch (member)
+            {
+                case IFieldSymbol f:
+                    if (f.Type is INamedTypeSymbol fn) yield return fn;
+                    break;
+                case IPropertySymbol p:
+                    if (p.Type is INamedTypeSymbol pn) yield return pn;
+                    break;
+                case IMethodSymbol m:
+                    if (m.ReturnType is INamedTypeSymbol rn) yield return rn;
+                    foreach (var param in m.Parameters)
+                        if (param.Type is INamedTypeSymbol paramN) yield return paramN;
+                    break;
+            }
+        }
+    }
+}

--- a/src/RoslynLens/TypeStructureHelper.cs
+++ b/src/RoslynLens/TypeStructureHelper.cs
@@ -20,20 +20,30 @@ internal static class TypeStructureHelper
         foreach (var member in type.GetMembers())
         {
             ct.ThrowIfCancellationRequested();
-            switch (member)
-            {
-                case IFieldSymbol f:
-                    if (f.Type is INamedTypeSymbol fn) yield return fn;
-                    break;
-                case IPropertySymbol p:
-                    if (p.Type is INamedTypeSymbol pn) yield return pn;
-                    break;
-                case IMethodSymbol m:
-                    if (m.ReturnType is INamedTypeSymbol rn) yield return rn;
-                    foreach (var param in m.Parameters)
-                        if (param.Type is INamedTypeSymbol paramN) yield return paramN;
-                    break;
-            }
+            foreach (var t in GetMemberTypes(member))
+                yield return t;
+        }
+    }
+
+    internal static bool IsSystemNamespace(string ns) =>
+        ns.StartsWith("System", StringComparison.Ordinal) ||
+        ns.StartsWith("Microsoft", StringComparison.Ordinal);
+
+    private static IEnumerable<INamedTypeSymbol> GetMemberTypes(ISymbol member)
+    {
+        switch (member)
+        {
+            case IFieldSymbol f:
+                if (f.Type is INamedTypeSymbol fn) yield return fn;
+                break;
+            case IPropertySymbol p:
+                if (p.Type is INamedTypeSymbol pn) yield return pn;
+                break;
+            case IMethodSymbol m:
+                if (m.ReturnType is INamedTypeSymbol rn) yield return rn;
+                foreach (var param in m.Parameters)
+                    if (param.Type is INamedTypeSymbol paramN) yield return paramN;
+                break;
         }
     }
 }

--- a/tests/RoslynLens.Tests/TypeStructureHelperTests.cs
+++ b/tests/RoslynLens.Tests/TypeStructureHelperTests.cs
@@ -1,0 +1,174 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Shouldly;
+
+namespace RoslynLens.Tests;
+
+public class TypeStructureHelperTests
+{
+    private static INamedTypeSymbol CompileType(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText(source)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        return compilation.GlobalNamespace.GetNamespaceMembers()
+            .SelectMany(ns => ns.GetTypeMembers())
+            .First();
+    }
+
+    [Fact]
+    public void CollectStructuralTypeRefs_ReturnsBaseType()
+    {
+        var type = CompileType("""
+            namespace A { public class Base { } }
+            namespace B { public class Child : A.Base { } }
+            """);
+
+        // The test type is A.Base (first namespace); use the child
+        var compilation = CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText("""
+                namespace B { public class Child : System.Collections.Generic.List<string> { } }
+                """)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+             MetadataReference.CreateFromFile(typeof(System.Collections.Generic.List<>).Assembly.Location)]);
+
+        var childType = compilation.GlobalNamespace
+            .GetNamespaceMembers().First()
+            .GetTypeMembers().First();
+
+        var refs = TypeStructureHelper.CollectStructuralTypeRefs(childType).ToList();
+        refs.ShouldContain(t => t.Name == "List");
+    }
+
+    [Fact]
+    public void CollectStructuralTypeRefs_ReturnsFieldType()
+    {
+        var compilation = CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText("""
+                namespace A
+                {
+                    public class Dep { }
+                    public class Owner { public Dep Field; }
+                }
+                """)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var owner = compilation.GlobalNamespace
+            .GetNamespaceMembers().First()
+            .GetTypeMembers()
+            .First(t => t.Name == "Owner");
+
+        var refs = TypeStructureHelper.CollectStructuralTypeRefs(owner).ToList();
+        refs.ShouldContain(t => t.Name == "Dep");
+    }
+
+    [Fact]
+    public void CollectStructuralTypeRefs_ReturnsPropertyType()
+    {
+        var compilation = CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText("""
+                namespace A
+                {
+                    public class Dep { }
+                    public class Owner { public Dep Prop { get; set; } }
+                }
+                """)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var owner = compilation.GlobalNamespace
+            .GetNamespaceMembers().First()
+            .GetTypeMembers()
+            .First(t => t.Name == "Owner");
+
+        var refs = TypeStructureHelper.CollectStructuralTypeRefs(owner).ToList();
+        refs.ShouldContain(t => t.Name == "Dep");
+    }
+
+    [Fact]
+    public void CollectStructuralTypeRefs_ReturnsMethodReturnAndParameterTypes()
+    {
+        var compilation = CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText("""
+                namespace A
+                {
+                    public class ReturnDep { }
+                    public class ParamDep { }
+                    public class Owner { public ReturnDep Method(ParamDep p) => null; }
+                }
+                """)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var owner = compilation.GlobalNamespace
+            .GetNamespaceMembers().First()
+            .GetTypeMembers()
+            .First(t => t.Name == "Owner");
+
+        var refs = TypeStructureHelper.CollectStructuralTypeRefs(owner).Select(t => t.Name).ToList();
+        refs.ShouldContain("ReturnDep");
+        refs.ShouldContain("ParamDep");
+    }
+
+    [Fact]
+    public void CollectStructuralTypeRefs_ReturnsInterface()
+    {
+        var compilation = CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText("""
+                namespace A
+                {
+                    public interface IService { }
+                    public class Impl : IService { }
+                }
+                """)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var impl = compilation.GlobalNamespace
+            .GetNamespaceMembers().First()
+            .GetTypeMembers()
+            .First(t => t.Name == "Impl");
+
+        var refs = TypeStructureHelper.CollectStructuralTypeRefs(impl).Select(t => t.Name).ToList();
+        refs.ShouldContain("IService");
+    }
+
+    [Fact]
+    public void CollectStructuralTypeRefs_EmptyForIsolatedType()
+    {
+        var compilation = CSharpCompilation.Create(
+            "Test",
+            [CSharpSyntaxTree.ParseText("namespace A { public class Standalone { } }")],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var type = compilation.GlobalNamespace
+            .GetNamespaceMembers().First()
+            .GetTypeMembers().First();
+
+        var refs = TypeStructureHelper.CollectStructuralTypeRefs(type).ToList();
+        refs.ShouldNotContain(t => t.ContainingNamespace.Name == "A");
+    }
+
+    [Theory]
+    [InlineData("System.Collections")]
+    [InlineData("System.Threading")]
+    [InlineData("Microsoft.Extensions.Logging")]
+    [InlineData("Microsoft.AspNetCore.Mvc")]
+    public void IsSystemNamespace_ReturnsTrueForFrameworkNamespaces(string ns)
+    {
+        TypeStructureHelper.IsSystemNamespace(ns).ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("MyApp.Services")]
+    [InlineData("Granit.Core")]
+    [InlineData("RoslynLens")]
+    public void IsSystemNamespace_ReturnsFalseForUserNamespaces(string ns)
+    {
+        TypeStructureHelper.IsSystemNamespace(ns).ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 4 new MCP tools that operate at the full solution graph level
  (inspired by structural patterns from [graphify-dotnet](https://github.com/elbruno/graphify-dotnet))
- Bundles NuGet dependency bumps from the pending 1.3.0 upgrade

## New tools

| Tool | Description |
| ---- | ----------- |
| `get_communities` | Partitions namespaces into cohesive communities via label-propagation; returns cohesion score (0–1) per community |
| `find_god_nodes` | Identifies types/methods whose incoming reference count exceeds mean + N×stddev — coupling hotspots |
| `find_surprising_dependencies` | Scores cross-namespace edges on 4 surprise factors (cross-assembly, peripheral-source, hub-target, semantic distance) |
| `find_isolated_symbols` | Finds degree-0 types: no incoming refs AND no structural outgoing refs — distinct from `find_dead_code` |

## NuGet bumps

- ModelContextProtocol 1.2.0 → 1.4.0
- Microsoft.Extensions.Hosting 10.0.6 → 10.0.8
- Microsoft.Build.Framework 18.4.0 → 18.6.3 + Microsoft.NET.StringTools 18.6.3
- ICSharpCode.Decompiler 10.0.0.8330 → 10.1.0.8386
- coverlet.collector 8.0.1 → 10.0.1, Microsoft.NET.Test.Sdk 18.3.0 → 18.6.0

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 162 tests passed
- [x] `npx markdownlint-cli2` — 0 errors on all modified `.md` files