### PR TITLE
fix(ci): pin pnpm version in website deploy workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,6 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          # Pinned explicitly: the action reads packageManager from the repo-root
+          # package.json (none here — this is a .NET repo), so it needs a version.
+          version: 11.5.3
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
The `Deploy website` workflow failed on `pnpm/action-setup@v4` with *No pnpm version is specified* — the action reads the `packageManager` field from the repo-root `package.json`, which doesn't exist in this .NET repo. Pin pnpm `11.5.3` explicitly so the site builds and deploys to GitHub Pages.

Unblocks the Pages deployment (Pages must also be enabled once in Settings → Pages → Source: GitHub Actions).