### PR TITLE
feat(website): add Releases (changelog) page

### DIFF
--- a/docs-website/src/components/Footer.astro
+++ b/docs-website/src/components/Footer.astro
@@ -12,8 +12,7 @@ const year = 2026;
         <div class="fname">{SITE.name}</div>
         <p class="ftag">{SITE.tagline}</p>
         <p class="fmaker">
-          From the builder of
-          <a href="https://granit-fx.dev" target="_blank" rel="noopener noreferrer">Granit&nbsp;FX ↗</a>
+          From the builder of <a href="https://granit-fx.dev" target="_blank">Granit&nbsp;Framework ↗</a>
         </p>
       </div>
     </div>

--- a/docs-website/src/components/Footer.astro
+++ b/docs-website/src/components/Footer.astro
@@ -11,6 +11,10 @@ const year = 2026;
       <div>
         <div class="fname">{SITE.name}</div>
         <p class="ftag">{SITE.tagline}</p>
+        <p class="fmaker">
+          From the builder of
+          <a href="https://granit-fx.dev" target="_blank" rel="noopener noreferrer">Granit&nbsp;FX ↗</a>
+        </p>
       </div>
     </div>
     <nav class="footer-nav">
@@ -33,6 +37,9 @@ const year = 2026;
   .brand-mark { width: 28px; height: 28px; border-radius: 8px; flex: none; display: block; }
   .fname { font-family: var(--font-display); font-weight: 700; }
   .ftag { margin: 2px 0 0; color: var(--text-muted); font-size: 0.9rem; max-width: 34ch; }
+  .fmaker { margin: 8px 0 0; font-size: 0.85rem; color: var(--text-faint); }
+  .fmaker a { color: var(--accent-2); border-bottom: 1px solid color-mix(in oklab, var(--accent-2) 40%, transparent); }
+  .fmaker a:hover { border-bottom-color: var(--accent-2); }
   .footer-nav { display: flex; gap: 1.3rem; flex-wrap: wrap; font-size: 0.92rem; }
   .footer-nav a { color: var(--text-muted); }
   .footer-nav a:hover { color: var(--text); }

--- a/docs-website/src/components/Header.astro
+++ b/docs-website/src/components/Header.astro
@@ -13,6 +13,7 @@ const docsHref = `${base}docs`;
     </a>
     <nav class="nav">
       <a href={docsHref}>Docs</a>
+      <a href={`${base}releases`}>Releases</a>
       <a href={`${docsHref}/comparison`}>Comparison</a>
       <a href={`${docsHref}/BENCHMARKS`}>Benchmark</a>
       <a href={SITE.github} target="_blank" rel="noopener noreferrer">GitHub ↗</a>
@@ -43,6 +44,6 @@ const docsHref = `${base}docs`;
   .nav a:hover { color: var(--text); }
   @media (max-width: 720px) {
     .nav { gap: 0.9rem; font-size: 0.86rem; }
-    .nav a:nth-child(2), .nav a:nth-child(3) { display: none; }
+    .nav a:nth-child(3), .nav a:nth-child(4) { display: none; }
   }
 </style>

--- a/docs-website/src/lib/releases.ts
+++ b/docs-website/src/lib/releases.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js';
+
+const CHANGELOG = path.resolve(process.cwd(), '..', 'CHANGELOG.md');
+const REPO = 'https://github.com/jfmeyers/roslyn-lens';
+
+export interface Release {
+  version: string;
+  date: string; // formatted, e.g. "Jul 4, 2026"
+  tag: string;
+  url: string;
+  bodyHtml: string;
+}
+
+const marked = new Marked(
+  markedHighlight({
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = lang && hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    },
+  }),
+);
+
+marked.use({
+  renderer: {
+    link({ href, title, tokens }) {
+      const text = this.parser.parseInline(tokens);
+      const external = /^https?:/i.test(href);
+      const attrs = [`href="${href}"`];
+      if (title) attrs.push(`title="${title}"`);
+      if (external) attrs.push('target="_blank"', 'rel="noopener noreferrer"');
+      return `<a ${attrs.join(' ')}>${text}</a>`;
+    },
+  },
+});
+
+// Reference-style link definitions (e.g. "[1.3.0]: https://…/compare/…") — not content.
+const REF_DEF = /^\[[^\]]+\]:\s+\S+/;
+
+function formatDate(iso: string): string {
+  const parsed = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** Parses CHANGELOG.md (Keep a Changelog format) into release entries, newest first. */
+export function getReleases(): Release[] {
+  const text = fs.readFileSync(CHANGELOG, 'utf8');
+  const headerRe = /^##\s+\[([^\]]+)\]\s*(?:-\s*(.+?))?\s*$/;
+  const releases: Release[] = [];
+  let current: { version: string; date: string; body: string[] } | null = null;
+
+  const flush = () => {
+    if (!current) return;
+    const body = current.body.filter((line) => !REF_DEF.test(line)).join('\n').trim();
+    const tag = `v${current.version}`;
+    releases.push({
+      version: current.version,
+      date: formatDate(current.date),
+      tag,
+      url: `${REPO}/releases/tag/${tag}`,
+      bodyHtml: marked.parse(body) as string,
+    });
+  };
+
+  for (const line of text.split('\n')) {
+    const match = line.match(headerRe);
+    if (match) {
+      flush();
+      current = { version: match[1], date: match[2] ?? '', body: [] };
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  flush();
+
+  return releases; // CHANGELOG is authored newest-first
+}

--- a/docs-website/src/pages/releases.astro
+++ b/docs-website/src/pages/releases.astro
@@ -1,0 +1,117 @@
+---
+import Base from '../layouts/Base.astro';
+import { getReleases } from '../lib/releases';
+import { SITE } from '../consts';
+
+const releases = getReleases();
+const latest = releases[0]?.version;
+const changelogUrl = `${SITE.github}/blob/main/CHANGELOG.md`;
+---
+
+<Base title="Releases" description={`Release history and changelog for ${SITE.name}.`}>
+  <section class="rel container">
+    <header class="sec-head">
+      <p class="eyebrow">Releases</p>
+      <h1>Changelog</h1>
+      <p class="sub">
+        Every version and its notes, generated from
+        <a href={changelogUrl} target="_blank" rel="noopener noreferrer">CHANGELOG.md</a>.
+        Install any version from
+        <a href={SITE.nuget} target="_blank" rel="noopener noreferrer">NuGet</a>.
+      </p>
+    </header>
+
+    <ol class="timeline">
+      {releases.map((r) => (
+        <li class="rel-item" id={r.tag}>
+          <div class="rel-head">
+            <div class="rel-title">
+              <a href={`#${r.tag}`} class="rel-tag">{r.tag}</a>
+              {r.version === latest && <span class="pill">latest</span>}
+            </div>
+            <span class="rel-date">{r.date}</span>
+          </div>
+          <div class="rel-notes" set:html={r.bodyHtml} />
+          <p class="rel-link">
+            <a href={r.url} target="_blank" rel="noopener noreferrer">View on GitHub →</a>
+          </p>
+        </li>
+      ))}
+    </ol>
+  </section>
+</Base>
+
+<style>
+  .rel { padding-top: 56px; padding-bottom: 24px; position: relative; z-index: 1; max-width: 860px; }
+  .sec-head { margin-bottom: 34px; }
+  .sec-head h1 { font-size: clamp(2rem, 5vw, 2.9rem); margin: 10px 0 0; }
+  .sub { color: var(--text-muted); margin-top: 12px; font-size: 1.05rem; max-width: 60ch; }
+  .sub a { color: var(--accent-2); border-bottom: 1px solid color-mix(in oklab, var(--accent-2) 40%, transparent); }
+
+  .timeline { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 18px; }
+  .rel-item {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 22px 26px;
+    box-shadow: var(--shadow);
+    scroll-margin-top: 86px;
+  }
+  .rel-head { display: flex; align-items: baseline; justify-content: space-between; gap: 14px; flex-wrap: wrap; }
+  .rel-title { display: inline-flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .rel-tag {
+    font-family: var(--font-mono);
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: var(--text);
+  }
+  .rel-tag:hover { color: var(--accent-2); }
+  .pill {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: #0a0b10;
+    background: linear-gradient(100deg, var(--accent), var(--accent-2));
+    padding: 3px 9px;
+    border-radius: 999px;
+  }
+  .rel-date { font-family: var(--font-mono); font-size: 0.82rem; color: var(--text-faint); }
+  .rel-link { margin: 18px 0 0; }
+  .rel-link a { font-family: var(--font-mono); font-size: 0.82rem; color: var(--text-muted); }
+  .rel-link a:hover { color: var(--accent-2); }
+
+  @media (max-width: 520px) {
+    .rel-item { padding: 18px; }
+  }
+</style>
+
+<style is:global>
+  .rel-notes { margin-top: 14px; color: var(--text-muted); font-size: 0.96rem; }
+  .rel-notes h3 {
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent-2);
+    margin: 20px 0 8px;
+  }
+  .rel-notes h3:first-child { margin-top: 0; }
+  .rel-notes ul { margin: 6px 0; padding-left: 1.2em; }
+  .rel-notes li { margin: 5px 0; }
+  .rel-notes li::marker { color: var(--text-faint); }
+  .rel-notes p { margin: 8px 0; }
+  .rel-notes a { color: var(--accent-2); border-bottom: 1px solid color-mix(in oklab, var(--accent-2) 40%, transparent); }
+  .rel-notes code {
+    font-family: var(--font-mono);
+    font-size: 0.84em;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    padding: 0.1em 0.36em;
+    color: var(--text);
+  }
+  .rel-notes strong { color: var(--text); }
+</style>

--- a/docs-website/src/pages/releases.astro
+++ b/docs-website/src/pages/releases.astro
@@ -14,10 +14,8 @@ const changelogUrl = `${SITE.github}/blob/main/CHANGELOG.md`;
       <p class="eyebrow">Releases</p>
       <h1>Changelog</h1>
       <p class="sub">
-        Every version and its notes, generated from
-        <a href={changelogUrl} target="_blank" rel="noopener noreferrer">CHANGELOG.md</a>.
-        Install any version from
-        <a href={SITE.nuget} target="_blank" rel="noopener noreferrer">NuGet</a>.
+        Every version and its notes, generated from <a href={changelogUrl} target="_blank" rel="noopener noreferrer">CHANGELOG.md</a>.
+        Install any version from <a href={SITE.nuget} target="_blank" rel="noopener noreferrer">NuGet</a>.
       </p>
     </header>
 


### PR DESCRIPTION
Adds a **Releases** page to the docs site (`/releases`), styled like the rest of the site, **generated from `CHANGELOG.md`** at build time (no GitHub API dependency).

Each version renders as a timeline card: version tag with anchor, date, a `latest` badge on the newest, the categorized notes (Added / Changed / …), and a *View on GitHub →* link to the tag. A **Releases** entry is added to the header nav.

Verified: build emits `/releases` with all 9 versions; screenshot checked in dark mode.