### PR TITLE
chore(website): add Google Search Console verification file

### DIFF
--- a/docs-website/public/google550f7f4c0033acfd.html
+++ b/docs-website/public/google550f7f4c0033acfd.html
@@ -1,0 +1,1 @@
+google-site-verification: google550f7f4c0033acfd.html


### PR DESCRIPTION
## What

Adds the Google Search Console verification file to the docs website so the site can be verified as an owned property.

The file lives in `docs-website/public/`, which Astro copies to the site root at build time. Given `base: '/roslyn-lens/'`, it is served at:

```
https://jfmeyers.github.io/roslyn-lens/google550f7f4c0033acfd.html
```

## Note

This verifies a **URL-prefix property** for `https://jfmeyers.github.io/roslyn-lens/`. If the Search Console property is instead the bare domain `jfmeyers.github.io`, the file must go in the user-pages repo (`jfmeyers.github.io`) rather than here, since this project site only serves under the `/roslyn-lens/` subpath.