### PR TITLE
refactor: resolve SonarCloud code smells

### DIFF
--- a/src/RoslynLens/Analyzers/DtoSuffixDetector.cs
+++ b/src/RoslynLens/Analyzers/DtoSuffixDetector.cs
@@ -33,7 +33,9 @@ public sealed class DtoSuffixDetector : IAntiPatternDetector
 
             if (!name.EndsWith("Dto", StringComparison.Ordinal) &&
                 !name.EndsWith("DTO", StringComparison.Ordinal))
+            {
                 continue;
+            }
 
             var line = typeDecl.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
             var kind = typeDecl is RecordDeclarationSyntax ? "record" : "class";

--- a/src/RoslynLens/Analyzers/EfCoreNoTrackingDetector.cs
+++ b/src/RoslynLens/Analyzers/EfCoreNoTrackingDetector.cs
@@ -89,13 +89,8 @@ public sealed class EfCoreNoTrackingDetector : IAntiPatternDetector
         }
 
         // Also check direct member access without invocation
-        if (current is MemberAccessExpressionSyntax ma &&
-            ma.Name.Identifier.Text is "AsNoTracking" or "AsNoTrackingWithIdentityResolution")
-        {
-            return true;
-        }
-
-        return false;
+        return current is MemberAccessExpressionSyntax ma &&
+            ma.Name.Identifier.Text is "AsNoTracking" or "AsNoTrackingWithIdentityResolution";
     }
 
     private static bool LooksLikeEfCoreQuery(ExpressionSyntax expression, SemanticModel model, CancellationToken ct)

--- a/src/RoslynLens/Analyzers/MissingConfigureAwaitDetector.cs
+++ b/src/RoslynLens/Analyzers/MissingConfigureAwaitDetector.cs
@@ -52,13 +52,8 @@ public sealed class MissingConfigureAwaitDetector : IAntiPatternDetector
     private static bool HasConfigureAwait(ExpressionSyntax expression)
     {
         // The expression should be an invocation of .ConfigureAwait(...)
-        if (expression is InvocationExpressionSyntax invocation &&
+        return expression is InvocationExpressionSyntax invocation &&
             invocation.Expression is MemberAccessExpressionSyntax access &&
-            access.Name.Identifier.Text == "ConfigureAwait")
-        {
-            return true;
-        }
-
-        return false;
+            access.Name.Identifier.Text == "ConfigureAwait";
     }
 }

--- a/src/RoslynLens/ComplexityAnalyzer.cs
+++ b/src/RoslynLens/ComplexityAnalyzer.cs
@@ -67,7 +67,7 @@ public static class ComplexityAnalyzer
 
                 case BinaryExpressionSyntax bin when bin.IsKind(SyntaxKind.LogicalAndExpression)
                     || bin.IsKind(SyntaxKind.LogicalOrExpression):
-                    total += 1;
+                    total++;
                     total += CalculateCognitiveRecursive(child, nesting);
                     break;
 
@@ -91,7 +91,7 @@ public static class ComplexityAnalyzer
             score += CalculateCognitiveRecursive(ifStmt.Statement, nesting + 1);
         if (ifStmt.Else is null) return score;
 
-        score += 1;
+        score++;
         score += ifStmt.Else.Statement is IfStatementSyntax
             ? CalculateCognitiveRecursive(ifStmt.Else, nesting)
             : CalculateCognitiveRecursive(ifStmt.Else, nesting + 1);

--- a/src/RoslynLens/GeneratedCode.cs
+++ b/src/RoslynLens/GeneratedCode.cs
@@ -28,7 +28,9 @@ internal static class GeneratedCode
 
         if (path.Contains("/obj/", StringComparison.OrdinalIgnoreCase) ||
             path.Contains("/bin/", StringComparison.OrdinalIgnoreCase))
+        {
             return true;
+        }
 
         var name = path[(path.LastIndexOf('/') + 1)..];
         return GeneratedSuffixes.Any(s => name.EndsWith(s, StringComparison.OrdinalIgnoreCase));

--- a/src/RoslynLens/SolutionDiscovery.cs
+++ b/src/RoslynLens/SolutionDiscovery.cs
@@ -23,10 +23,7 @@ public static class SolutionDiscovery
             return explicitPath;
 
         var envPath = ParseEnvPath();
-        if (envPath is not null)
-            return envPath;
-
-        return BfsDiscovery(Directory.GetCurrentDirectory());
+        return envPath ?? BfsDiscovery(Directory.GetCurrentDirectory());
     }
 
     // Lets a host (e.g. the MCP bundle) point at a solution without passing CLI args.
@@ -86,7 +83,7 @@ public static class SolutionDiscovery
             {
                 bestMatch = ScanDirectoryForSolution(dirPath, depth, bestMatch, ref bestDepth);
 
-                if (bestMatch is not null && bestMatch.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) && depth == bestDepth)
+                if (bestMatch?.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) == true && depth == bestDepth)
                     return bestMatch;
 
                 EnqueueSubDirectories(queue, dirPath, depth);

--- a/src/RoslynLens/SymbolResolver.cs
+++ b/src/RoslynLens/SymbolResolver.cs
@@ -77,8 +77,7 @@ public static class SymbolResolver
             var match = candidates.FirstOrDefault(s =>
             {
                 var loc = GetLocation(s);
-                return loc.FilePath is not null &&
-                       loc.FilePath.Replace('\\', '/').EndsWith(normalized, StringComparison.OrdinalIgnoreCase);
+                return loc.FilePath?.Replace('\\', '/').EndsWith(normalized, StringComparison.OrdinalIgnoreCase) == true;
             });
             if (match is not null) return match;
         }

--- a/src/RoslynLens/ToolInvocationLogging.cs
+++ b/src/RoslynLens/ToolInvocationLogging.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -13,6 +14,11 @@ namespace RoslynLens;
 /// </summary>
 public static class ToolInvocationLogging
 {
+    // This is the outermost tool-call boundary: logging a failure with its correlation id here
+    // and rethrowing is intentional — nothing above re-logs it, and wrapping would discard the
+    // original exception type the MCP dispatcher relies on to build the JSON-RPC error.
+    [SuppressMessage("Major Code Smell", "S2139:Exceptions should be either logged or rethrown but not both",
+        Justification = "Outermost boundary filter: the correlation-scoped failure log is the purpose of this filter, and the original exception must propagate unwrapped.")]
     public static IMcpServerBuilder WithToolInvocationLogging(this IMcpServerBuilder builder)
     {
         return builder.WithRequestFilters(filters =>
@@ -26,22 +32,27 @@ public static class ToolInvocationLogging
 
                 using var scope = logger?.BeginScope("cid:{CorrelationId}", correlationId);
                 var stopwatch = Stopwatch.StartNew();
-                logger?.LogInformation("→ {Tool} started [cid {CorrelationId}]", toolName, correlationId);
+                if (logger?.IsEnabled(LogLevel.Information) == true)
+                    logger.LogInformation("→ {Tool} started [cid {CorrelationId}]", toolName, correlationId);
 
                 try
                 {
                     var result = await next(ctx, ct);
                     stopwatch.Stop();
-                    logger?.LogInformation(
-                        "← {Tool} completed in {ElapsedMs}ms [cid {CorrelationId}]",
-                        toolName, stopwatch.ElapsedMilliseconds, correlationId);
+                    if (logger?.IsEnabled(LogLevel.Information) == true)
+                    {
+                        logger.LogInformation(
+                            "← {Tool} completed in {ElapsedMs}ms [cid {CorrelationId}]",
+                            toolName, stopwatch.ElapsedMilliseconds, correlationId);
+                    }
+
                     return result;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException ex)
                 {
                     stopwatch.Stop();
                     logger?.LogWarning(
-                        "⊘ {Tool} cancelled after {ElapsedMs}ms [cid {CorrelationId}]",
+                        ex, "⊘ {Tool} cancelled after {ElapsedMs}ms [cid {CorrelationId}]",
                         toolName, stopwatch.ElapsedMilliseconds, correlationId);
                     throw;
                 }

--- a/src/RoslynLens/Tools/AnalyzeControlFlowTool.cs
+++ b/src/RoslynLens/Tools/AnalyzeControlFlowTool.cs
@@ -24,7 +24,7 @@ public static class AnalyzeControlFlowTool
             return Json.Serialize(new { error = "Control flow analysis requires a block body with statements" });
 
         var analysis = model.AnalyzeControlFlow(block.Statements.First(), block.Statements.Last());
-        if (analysis is null || !analysis.Succeeded)
+        if (analysis?.Succeeded != true)
             return Json.Serialize(new { error = "Control flow analysis failed" });
 
         var result = new ControlFlowResult(

--- a/src/RoslynLens/Tools/AnalyzeDataFlowTool.cs
+++ b/src/RoslynLens/Tools/AnalyzeDataFlowTool.cs
@@ -32,7 +32,7 @@ public static class AnalyzeDataFlowTool
             analysis = model.AnalyzeDataFlow(arrow.Expression);
         }
 
-        if (analysis is null || !analysis.Succeeded)
+        if (analysis?.Succeeded != true)
             return Json.Serialize(new { error = "Data flow analysis failed" });
 
         var result = new DataFlowResult(

--- a/src/RoslynLens/Tools/DetectAntiPatternsTool.cs
+++ b/src/RoslynLens/Tools/DetectAntiPatternsTool.cs
@@ -78,7 +78,7 @@ public static class DetectAntiPatternsTool
 
         var normalizedFile = file.Replace('\\', '/');
         var treePath = tree.FilePath?.Replace('\\', '/');
-        return treePath is not null && treePath.EndsWith(normalizedFile, StringComparison.OrdinalIgnoreCase);
+        return treePath?.EndsWith(normalizedFile, StringComparison.OrdinalIgnoreCase) == true;
     }
 
     private static void AnalyzeTree(

--- a/src/RoslynLens/Tools/DetectCircularDependenciesTool.cs
+++ b/src/RoslynLens/Tools/DetectCircularDependenciesTool.cs
@@ -42,7 +42,9 @@ public static class DetectCircularDependenciesTool
         {
             if (projectFilter is not null &&
                 !project.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
+            {
                 continue;
+            }
 
             var refs = project.ProjectReferences
                 .Select(r => solution.GetProject(r.ProjectId)?.Name)

--- a/src/RoslynLens/Tools/FindDeadCodeTool.cs
+++ b/src/RoslynLens/Tools/FindDeadCodeTool.cs
@@ -221,8 +221,8 @@ public static class FindDeadCodeTool
     private static bool HasTestAttribute(IMethodSymbol methodSymbol)
     {
         return methodSymbol.GetAttributes()
-            .Where(attr => attr.AttributeClass?.Name is not null)
-            .Any(attr => TestAttributes.Contains(attr.AttributeClass!.Name.Replace("Attribute", "")));
+            .Any(attr => attr.AttributeClass?.Name is not null
+                && TestAttributes.Contains(attr.AttributeClass.Name.Replace("Attribute", "")));
     }
 
     private static List<Project> GetProjectsInScope(Solution solution, string scope, string? path)

--- a/src/RoslynLens/Tools/FindGodNodesTool.cs
+++ b/src/RoslynLens/Tools/FindGodNodesTool.cs
@@ -38,10 +38,10 @@ public static class FindGodNodesTool
         if (candidates.Count == 0)
             return Json.Serialize(new GodNodesResult([], 0, 0, 0, 0));
 
-        var refCounts = candidates.Select(c => (double)c.RefCount).ToList();
+        var refCounts = candidates.ConvertAll(c => (double)c.RefCount);
         var mean = refCounts.Average();
         var stdDev = Math.Sqrt(refCounts.Average(x => Math.Pow(x - mean, 2)));
-        var cutoff = mean + threshold * stdDev;
+        var cutoff = mean + (threshold * stdDev);
 
         var godNodes = candidates
             .Where(c => c.RefCount >= minRefs && c.RefCount >= cutoff)
@@ -73,8 +73,10 @@ public static class FindGodNodesTool
             if (compilation is null) continue;
 
             await foreach (var (root, model) in TypeStructureHelper.GetTreeRootsAsync(compilation, ct))
+            {
                 foreach (var symbol in CollectSymbols(root, model, kind, ct))
                     await ProcessSymbolAsync(symbol, solution, project.Name, seen, candidates, ct);
+            }
         }
 
         return candidates;

--- a/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
+++ b/src/RoslynLens/Tools/FindIsolatedSymbolsTool.cs
@@ -116,9 +116,13 @@ public static class FindIsolatedSymbolsTool
             if (compilation is null) continue;
 
             await foreach (var (root, model) in TypeStructureHelper.GetTreeRootsAsync(compilation, ct))
+            {
                 foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                {
                     if (model.GetDeclaredSymbol(typeDecl, ct) is INamedTypeSymbol type)
                         names.Add(type.ToDisplayString());
+                }
+            }
         }
 
         return names;

--- a/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
+++ b/src/RoslynLens/Tools/FindSurprisingDependenciesTool.cs
@@ -150,7 +150,7 @@ public static class FindSurprisingDependenciesTool
         double hubThreshold = meanInDegree + stdInDegree;
 
         double medianOutDegree = outDegree.Count > 0
-            ? outDegree.Values.OrderBy(x => x).ElementAt(outDegree.Count / 2)
+            ? outDegree.Values.Order().ElementAt(outDegree.Count / 2)
             : 0;
 
         var scored = new List<(int Score, List<string> Reasons, string From, string To, int RefCount)>();
@@ -202,14 +202,14 @@ public static class FindSurprisingDependenciesTool
         var tgtIn = inDegree.GetValueOrDefault(key.To);
         if (tgtIn > hubThreshold)
         {
-            score += 1;
+            score++;
             reasons.Add($"hub target ({tgtIn} incoming deps)");
         }
 
         var distance = ComputeNamespaceDistance(key.From, key.To);
         if (distance >= 3)
         {
-            score += 1;
+            score++;
             reasons.Add($"distant namespaces (depth diff {distance})");
         }
 

--- a/src/RoslynLens/Tools/GetCommunitiesTool.cs
+++ b/src/RoslynLens/Tools/GetCommunitiesTool.cs
@@ -65,8 +65,10 @@ public static class GetCommunitiesTool
         CancellationToken ct)
     {
         await foreach (var (root, model) in TypeStructureHelper.GetTreeRootsAsync(compilation, ct))
+        {
             foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
                 RegisterTypeEdges(typeDecl, model, nsEdges, ct);
+        }
     }
 
     private static void RegisterTypeEdges(

--- a/src/RoslynLens/Tools/GetComplexityMetricsTool.cs
+++ b/src/RoslynLens/Tools/GetComplexityMetricsTool.cs
@@ -21,9 +21,7 @@ public static class GetComplexityMetricsTool
         CancellationToken ct = default)
     {
         var status = workspace.EnsureReadyOrStatus(ct);
-        if (status is not null) return status;
-
-        return scope.ToLowerInvariant() switch
+        return status ?? scope.ToLowerInvariant() switch
         {
             "type" => await AnalyzeTypeAsync(workspace, name, threshold, maxResults, ct),
             "project" => await AnalyzeProjectAsync(workspace, name, threshold, maxResults, ct),

--- a/src/RoslynLens/Tools/GetModuleDependsOnTool.cs
+++ b/src/RoslynLens/Tools/GetModuleDependsOnTool.cs
@@ -109,8 +109,8 @@ public static class GetModuleDependsOnTool
 
         var dependsOnArgs = classDecl.AttributeLists
             .SelectMany(al => al.Attributes)
-            .Where(a => a.Name.ToString() is "DependsOn" or "DependsOnAttribute")
-            .Where(a => a.ArgumentList is not null)
+            .Where(a => a.Name.ToString() is "DependsOn" or "DependsOnAttribute"
+                && a.ArgumentList is not null)
             .SelectMany(a => a.ArgumentList!.Arguments);
 
         foreach (var arg in dependsOnArgs)
@@ -190,13 +190,11 @@ public static class GetModuleDependsOnTool
         else
         {
             children = info?.DependsOn
-                .Select(d => ResolveModuleName(d, moduleMap) ?? d)
-                .ToList() ?? [];
+                .ConvertAll(d => ResolveModuleName(d, moduleMap) ?? d) ?? [];
         }
 
         var childDeps = children
-            .Select(c => BuildTree(c, moduleMap, reverseMap, remainingDepth - 1, visited))
-            .ToList();
+            .ConvertAll(c => BuildTree(c, moduleMap, reverseMap, remainingDepth - 1, visited));
 
         visited.Remove(moduleName); // Allow the same module to appear in different branches
 

--- a/src/RoslynLens/Tools/GetProjectGraphTool.cs
+++ b/src/RoslynLens/Tools/GetProjectGraphTool.cs
@@ -73,7 +73,7 @@ public static class GetProjectGraphTool
         {
             ct.ThrowIfCancellationRequested();
 
-            if (matchingNames is not null && !matchingNames.Contains(project.Name))
+            if (matchingNames?.Contains(project.Name) == false)
                 continue;
 
             var references = project.ProjectReferences

--- a/src/RoslynLens/Tools/GetPublicApiBatchTool.cs
+++ b/src/RoslynLens/Tools/GetPublicApiBatchTool.cs
@@ -37,9 +37,9 @@ public static class GetPublicApiBatchTool
                 }
 
                 var members = typeSymbol.GetMembers()
-                    .Where(m => m.DeclaredAccessibility == Accessibility.Public)
-                    .Where(m => !m.IsImplicitlyDeclared)
-                    .Where(m => m is not IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
+                    .Where(m => m.DeclaredAccessibility == Accessibility.Public
+                        && !m.IsImplicitlyDeclared
+                        && m is not IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
                     .Select(m =>
                     {
                         var kind = m switch

--- a/src/RoslynLens/Tools/GetPublicApiTool.cs
+++ b/src/RoslynLens/Tools/GetPublicApiTool.cs
@@ -24,9 +24,9 @@ public static class GetPublicApiTool
             return Json.Serialize(new PublicApiResult(typeName, [], 0));
 
         var members = typeSymbol.GetMembers()
-            .Where(m => m.DeclaredAccessibility == Accessibility.Public)
-            .Where(m => !m.IsImplicitlyDeclared)
-            .Where(m => m is not IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
+            .Where(m => m.DeclaredAccessibility == Accessibility.Public
+                && !m.IsImplicitlyDeclared
+                && m is not IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
             .Select(m =>
             {
                 var kind = m switch

--- a/src/RoslynLens/Tools/GetTestCoverageMapTool.cs
+++ b/src/RoslynLens/Tools/GetTestCoverageMapTool.cs
@@ -27,8 +27,8 @@ public static class GetTestCoverageMapTool
         var testClassMap = await BuildTestClassMapAsync(workspace, solution, ct);
 
         var productionProjects = solution.Projects
-            .Where(p => !IsTestProject(p.Name))
-            .Where(p => projectFilter is null || p.Name.Equals(projectFilter, StringComparison.OrdinalIgnoreCase))
+            .Where(p => !IsTestProject(p.Name)
+                && (projectFilter is null || p.Name.Equals(projectFilter, StringComparison.OrdinalIgnoreCase)))
             .ToList();
 
         var (entries, covered, uncovered) = await MatchProductionTypesAsync(
@@ -51,8 +51,10 @@ public static class GetTestCoverageMapTool
             if (compilation is null) continue;
 
             await foreach (var (root, _) in TypeStructureHelper.GetTreeRootsAsync(compilation, ct))
+            {
                 foreach (var typeDecl in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
                     testClassMap.TryAdd(typeDecl.Identifier.Text, (root.SyntaxTree.FilePath, testProject.Name));
+            }
         }
 
         return testClassMap;

--- a/src/RoslynLens/Tools/GetTypeOverviewTool.cs
+++ b/src/RoslynLens/Tools/GetTypeOverviewTool.cs
@@ -36,9 +36,9 @@ public static class GetTypeOverviewTool
     private static PublicApiResult BuildPublicApi(INamedTypeSymbol typeSymbol)
     {
         var members = typeSymbol.GetMembers()
-            .Where(m => m.DeclaredAccessibility == Accessibility.Public)
-            .Where(m => !m.IsImplicitlyDeclared)
-            .Where(m => m is not IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
+            .Where(m => m.DeclaredAccessibility == Accessibility.Public
+                && !m.IsImplicitlyDeclared
+                && m is not IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
             .Select(ToApiMember).ToList();
         return new PublicApiResult(typeSymbol.ToDisplayString(), members, members.Count);
     }

--- a/src/RoslynLens/Tools/ListSolutionsTool.cs
+++ b/src/RoslynLens/Tools/ListSolutionsTool.cs
@@ -9,9 +9,7 @@ public static class ListSolutionsTool
 {
     [McpServerTool(Name = "list_solutions", ReadOnly = true, Idempotent = true, OpenWorld = false)]
     [Description("Lists all discovered solution files with their paths and which one is currently active.")]
-    public static Task<string> ExecuteAsync(
-        WorkspaceManager workspace,
-        CancellationToken ct = default)
+    public static Task<string> ExecuteAsync()
     {
         var discovered = WorkspaceInitializer.DiscoveredSolutions;
         var activePath = WorkspaceInitializer.SolutionPath;

--- a/src/RoslynLens/Tools/ValidateGranitConventionsTool.cs
+++ b/src/RoslynLens/Tools/ValidateGranitConventionsTool.cs
@@ -359,8 +359,8 @@ public static class ValidateGranitConventionsTool
 
         var typeOfArgs = classDecl.AttributeLists
             .SelectMany(al => al.Attributes)
-            .Where(a => a.Name.ToString() is "DependsOn" or "DependsOnAttribute")
-            .Where(a => a.ArgumentList is not null)
+            .Where(a => a.Name.ToString() is "DependsOn" or "DependsOnAttribute"
+                && a.ArgumentList is not null)
             .SelectMany(a => a.ArgumentList!.Arguments)
             .Select(arg => arg.Expression)
             .OfType<TypeOfExpressionSyntax>();

--- a/src/RoslynLens/WorkspaceManager.cs
+++ b/src/RoslynLens/WorkspaceManager.cs
@@ -12,7 +12,6 @@ public sealed class WorkspaceManager : IDisposable
 {
     private const int LazyLoadThreshold = 10;
 
-    private readonly RoslynLensConfig _config;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private readonly ConcurrentDictionary<ProjectId, (Compilation Compilation, long AccessCount)> _compilationCache = new();
     private long _accessCounter;
@@ -25,11 +24,11 @@ public sealed class WorkspaceManager : IDisposable
     private FileSystemWatcher? _projectWatcher;
     private string? _solutionDirectory;
 
-    public RoslynLensConfig Config => _config;
+    public RoslynLensConfig Config { get; }
 
     public WorkspaceManager(RoslynLensConfig config)
     {
-        _config = config;
+        Config = config;
     }
 
     public WorkspaceState State { get; private set; } = WorkspaceState.NotStarted;
@@ -126,7 +125,7 @@ public sealed class WorkspaceManager : IDisposable
             try
             {
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                cts.CancelAfter(TimeSpan.FromSeconds(_config.TimeoutSeconds));
+                cts.CancelAfter(TimeSpan.FromSeconds(Config.TimeoutSeconds));
                 _readySignal.Task.Wait(cts.Token);
             }
             catch (OperationCanceledException)
@@ -190,7 +189,7 @@ public sealed class WorkspaceManager : IDisposable
         _compilationCache[project.Id] = (compilation, accessCount);
 
         // Evict LRU if over capacity
-        if (_compilationCache.Count > _config.CacheSize)
+        if (_compilationCache.Count > Config.CacheSize)
         {
             var lruKey = _compilationCache
                 .OrderBy(kvp => kvp.Value.AccessCount)

--- a/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
+++ b/tests/RoslynLens.Tests/Tools/ListSolutionsToolTests.cs
@@ -29,7 +29,7 @@ public class ListSolutionsToolTests : IDisposable
             WorkspaceInitializer.DiscoveredSolutions = [pathA, pathB];
             WorkspaceInitializer.SolutionPath = pathA;
 
-            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+            var result = await ListSolutionsTool.ExecuteAsync();
 
             using var doc = JsonDocument.Parse(result);
             var root = doc.RootElement;
@@ -59,7 +59,7 @@ public class ListSolutionsToolTests : IDisposable
         {
             WorkspaceInitializer.DiscoveredSolutions = [];
 
-            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+            var result = await ListSolutionsTool.ExecuteAsync();
 
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("Solutions").GetArrayLength().ShouldBe(0);
@@ -85,7 +85,7 @@ public class ListSolutionsToolTests : IDisposable
             WorkspaceInitializer.DiscoveredSolutions = [pathA, pathB, pathC];
             WorkspaceInitializer.SolutionPath = pathA;
 
-            var result = await ListSolutionsTool.ExecuteAsync(_workspace, TestContext.Current.CancellationToken);
+            var result = await ListSolutionsTool.ExecuteAsync();
 
             using var doc = JsonDocument.Parse(result);
             var hint = doc.RootElement.GetProperty("Hint").GetString();


### PR DESCRIPTION
## Summary

Resolves the SonarCloud code smells reported across the analyzers, tools and core, verified against the actual Roslynator/Sonar rule IDs (temporarily enabled the analyzers locally to capture exact rule IDs + locations, then reverted).

## Changes

**Roslynator rules (37 issues, 26 files):**
- `RCS1001` add braces to multi-line `if`/`foreach`
- `RCS1073` convert `if` to `return`
- `RCS1089` use `++` instead of `+= 1`
- `RCS1146` use conditional access
- `RCS1173` use coalesce expression instead of `if`
- `RCS1077` optimize LINQ (`Where`+`Any`→`Any`, `Select().ToList()`→`ConvertAll`, `OrderBy(x=>x)`→`Order()`)
- `RCS1112` combine `Where` chains
- `RCS1123` add parentheses for operator precedence
- `RCS1085` use auto-implemented property (`WorkspaceManager.Config`)
- `RCS1163` remove unused parameters (`ListSolutionsTool`, test call sites updated)

**`ToolInvocationLogging` (SonarC# rules):**
- `S2629` — guard the `Information` logs with `IsEnabled`
- `S6667` — pass the caught exception to the cancellation log
- `S2139` — kept the log-and-rethrow at the outermost tool boundary (wrapping would discard the exception type the MCP dispatcher relies on) and documented it with a justified `SuppressMessage`

## Verification

- `dotnet build` — **0 warnings, 0 errors** (TreatWarningsAsErrors on)
- `dotnet test` — **203 passed, 0 failed**
- No behavioral change